### PR TITLE
XPath query fixed to associate TTS tags for elements with layer tag. Resolves #11

### DIFF
--- a/app/src/main/java/com/example/hw/MainActivity.java
+++ b/app/src/main/java/com/example/hw/MainActivity.java
@@ -349,8 +349,7 @@ public class MainActivity extends AppCompatActivity implements GestureDetector.O
         XPath xPath = XPathFactory.newInstance().newXPath();
         // query elements that are in the present layer AND have element level descriptions (NOT layer level descriptions)
         // Assuming that only elements with short description can have a long description here. Is this assumption safe?!
-        NodeList nodeslist=(NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@display]) and not(descendant::*[@display]) and not(self::*[@data-image-layer]) and (self::*[@aria-labelledby] or self::*[@aria-label])]", doc, XPathConstants.NODESET);
-        // temporary var for objects tags
+        NodeList nodeslist=(NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@display]) and not(descendant::*[@display]) and (not(self::*[@data-image-layer]) or not(child::*)) and (self::*[@aria-labelledby] or self::*[@aria-label])]", doc, XPathConstants.NODESET);        // temporary var for objects tags
         String[] layerTags=new String[brailleServiceObj.getDotPerLineCount()*brailleServiceObj.getDotLineCount()];
         // temporary var for objects long descriptions
         String[] layerDesc=new String[brailleServiceObj.getDotPerLineCount()*brailleServiceObj.getDotLineCount()];


### PR DESCRIPTION
XPath query fixed to associate TTS tags with individual elements that also have tag 'data-image-layer' (resolves #11). 

Tested with:
```
<?xml version="1.0" encoding="UTF-8"?>
<svg width="200" height="100" viewbox="0 0 200 100"> 
  <g data-image-layer="firstLayer" aria-labelledby="circleDesc">
    <desc id="circleDesc">Circles Layer</desc>
    <circle cx="100" cy="50" r="25" fill="black" aria-labelledby="circle1" aria-describedby="desc1"/>
    <desc id="circle1">Circle 1</desc>
    <desc id="desc1">a small circle in the center of the display</desc>
    <circle cx="200" cy="50" r="25" fill="black" aria-label="Circle 2" aria-description="a small circle at the edge of the display"/>
  </g>
  <rect x="75" y="25" width="50" height="50" fill="none" stroke="black" stroke-width="1" data-image-layer="secondLayer" aria-label="Rectangle" aria-description="a rectangle bounding the circle"/>
</svg>
```