### PR TITLE
Detail tag append implementation correction. Resolves #24

### DIFF
--- a/app/src/main/java/com/example/hw/MainActivity.java
+++ b/app/src/main/java/com/example/hw/MainActivity.java
@@ -396,11 +396,14 @@ public class MainActivity extends AppCompatActivity implements GestureDetector.O
                     else {
                         layerTags[j]= layerTags[j] + ", " + tag;
                     }
-                    if (layerDesc[j]==null){
-                        layerDesc[j]=detailTag;
-                    }
-                    else {
-                        layerDesc[j]= layerDesc[j] + ", " + tag;
+                    //check if detailTag is not blank string. Empty string check doesn't work as expected??
+                    if (detailTag.trim().length() > 0){
+                        if (layerDesc[j]==null){
+                            layerDesc[j]=detailTag;
+                        }
+                        else {
+                            layerDesc[j]= layerDesc[j] + ", " + detailTag;
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/hw/MainActivity.java
+++ b/app/src/main/java/com/example/hw/MainActivity.java
@@ -396,8 +396,8 @@ public class MainActivity extends AppCompatActivity implements GestureDetector.O
                     else {
                         layerTags[j]= layerTags[j] + ", " + tag;
                     }
-                    //check if detailTag is not blank string. Empty string check doesn't work as expected??
-                    if (detailTag.trim().length() > 0){
+                    //check if detailTag is not blank string.
+                    if (!detailTag.equalsIgnoreCase("")){
                         if (layerDesc[j]==null){
                             layerDesc[j]=detailTag;
                         }


### PR DESCRIPTION
Changes have been made to:
1. Append the long description when a region has more than one long description. Earlier, the short label was appended instead of the detailed description. Tested with:
```
<svg width="200" height="100" viewbox="0 0 200 100"> 
  <g data-image-layer="firstLayer" aria-labelledby="circleDesc">
    <desc id="circleDesc">Circles Layer</desc>
    <circle cx="100" cy="50" r="25" fill="black" aria-labelledby="circle1" aria-describedby="desc1"/>
    <desc id="circle1">Circle 1</desc>
    <desc id="desc1">a small circle in the center of the display</desc>
    <circle cx="200" cy="50" r="25" fill="black" aria-label="Circle 2" aria-description="a small circle at the edge of the display"/>
  </g>
  <rect x="75" y="25" width="50" height="50" fill="none" stroke="black" stroke-width="1" data-image-layer="secondLayer" aria-label="Rectangle" aria-description="a rectangle bounding the circle"/>
</svg>
```
2. Check if the detailTag is empty before appending to the TTS tags to avoid "," being added in when no description is present as noted in #24. 

Resolves #24 

