### PR TITLE
Modifying the button triggers so that the UI works with the new 'point and click' mode. Resolves #31

### DIFF
--- a/app/src/main/java/com/example/hw/MainActivity.java
+++ b/app/src/main/java/com/example/hw/MainActivity.java
@@ -307,7 +307,12 @@ public class MainActivity extends AppCompatActivity implements GestureDetector.O
                 return false;
             }
         });
-
+        debugSwitch.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                debugSwitch.setChecked(!debugSwitch.isChecked());
+            }
+        });
     }
 
 


### PR DESCRIPTION
The onClickListener for the UI buttons was removed to accommodate the interaction style with 'point and click'.
It was replaced with onKeyListener.

UI buttons can now be triggered by the 'confirm button' (i.e. the button currently used as the _standard_ confirm button for Monarch; keyCode = 504).

This was tested on the device to ensure that all buttons can now be triggered with the confirm button but not with a click (central orange button). 

Resolves #31 