### PR TITLE
Disabling TTS when the pins are lowered. Resolevs #21

### DIFF
--- a/app/src/main/java/com/example/hw/MainActivity.java
+++ b/app/src/main/java/com/example/hw/MainActivity.java
@@ -101,7 +101,7 @@ public class MainActivity extends AppCompatActivity implements GestureDetector.O
     private byte[][] data = null; // byte array used to reset pins
 
     //variable to change whether TTS tags fill the object or are assigned only to the raised edges.
-    boolean labelFill=true, touchEnabled=true;
+    boolean labelFill=true, ttsEnabled=true;
     int layercount; // number of layers found in svg
     String image;// used to store svg in string format
 
@@ -213,7 +213,7 @@ public class MainActivity extends AppCompatActivity implements GestureDetector.O
                 int pinY= (int) Math.ceil((e.getY()-yMin+0.000001)/((yMax-yMin)/brailleServiceObj.getDotLineCount()))-1;
                 //Log.d(TAG, String.valueOf(e.getX())+","+String.valueOf(e.getY())+ " ; "+ pinX+","+pinY);
                 */
-               if(touchEnabled){
+               if(ttsEnabled){
                 try{
                     // This works! Gesture control can now be used along with the handler.
                     onTouchEvent(e);
@@ -235,7 +235,7 @@ public class MainActivity extends AppCompatActivity implements GestureDetector.O
                 if (((Button) findViewById(R.id.zeros)).hasFocus() &&
                         keyEvent.getKeyCode()==confirmButton &&
                         keyEvent.getAction()== KeyEvent.ACTION_DOWN){
-                    touchEnabled=false;
+                    ttsEnabled=false;
                     brailleServiceObj.display(data);
                 }
                 return false;
@@ -250,7 +250,7 @@ public class MainActivity extends AppCompatActivity implements GestureDetector.O
                         keyEvent.getAction()== KeyEvent.ACTION_DOWN){
                 try {
                     // Display current layer
-                    touchEnabled=true;
+                    ttsEnabled=true;
                     brailleServiceObj.display(getBitmaps(getfreshDoc(), presentLayer++));
                 } catch (IOException e) {
                     throw new RuntimeException(e);


### PR DESCRIPTION
Made changes in the way touch events are handled when the pins are lowered so that it is no longer possible to trigger the TTS when the pins corresponding to the labels are not raised.

Resolves #21 