### PR TITLE
Incorporate UI features and send follow up query to server

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,12 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.BrailleDisplay">
         <activity
+            android:name=".FollowUpQuery"
+            android:exported="false" />
+        <activity
+            android:name=".RendererBaseActivity"
+            android:exported="false" />
+        <activity
             android:name=".selectors.ClassroomSelector"
             android:exported="false" />
         <activity
@@ -59,7 +65,7 @@
         <activity
             android:name=".renderers.Exploration"
             android:configChanges="touchscreen"
-            android:exported="true"></activity>
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/app/src/main/java/ca/mcgill/a11y/image/BaseActivity.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/BaseActivity.java
@@ -79,6 +79,10 @@ public class BaseActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         // View Actions
         setContentView(R.layout.activity_main);
+        if(ContextCompat.checkSelfPermission(getApplicationContext(), Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED){
+            checkPermission();
+        }
+
         if (DataAndMethods.brailleServiceObj==null) {
             brailleServiceObj = (BrailleDisplay) getSystemService(BrailleDisplay.BRAILLE_DISPLAY_SERVICE);
             DataAndMethods.initialize(brailleServiceObj, getApplicationContext(), findViewById(android.R.id.content));
@@ -98,6 +102,12 @@ public class BaseActivity extends AppCompatActivity {
 
         this.getOnBackPressedDispatcher().addCallback(onBackPressedCallback);*/
 
+    }
+    // check permissions required for voice recognition
+    private void checkPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            ActivityCompat.requestPermissions(this,new String[]{Manifest.permission.RECORD_AUDIO},1);
+        }
     }
 
     @Override

--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -809,23 +809,23 @@ public class DataAndMethods {
                     if (response.raw().networkResponse().code() != HttpURLConnection.HTTP_NOT_MODIFIED || image == null) {
                         ResponseFormat resource = response.body();
                         ResponseFormat.Rendering[] renderings = resource.renderings;
-                        if (!history.temp_request.has("followup")){
-                        image =(renderings[0].data.graphic).replaceFirst("data:.+,", "");
-                        //Log.d("RESPONSE", image);
-                        byte[] data = image.getBytes("UTF-8");
-                        data = Base64.decode(data, Base64.DEFAULT);
-                        image = new String(data, "UTF-8");
-                        // Log.d("IMAGE", image);
-                        // gets viewBox dims for current image
-                        resetGraphicParams();
-                        setImageDims();
-                        targetCounts();
-                        if (renderings[0].data.layer != null) {
-                            setDefaultLayer(renderings[0].data.layer);
-                        }
-                        else{
-                            presentLayer = -1;
-                        }
+                        if (history.temp_request == null || !history.temp_request.has("followup")){
+                            image =(renderings[0].data.graphic).replaceFirst("data:.+,", "");
+                            //Log.d("RESPONSE", image);
+                            byte[] data = image.getBytes("UTF-8");
+                            data = Base64.decode(data, Base64.DEFAULT);
+                            image = new String(data, "UTF-8");
+                            // Log.d("IMAGE", image);
+                            // gets viewBox dims for current image
+                            resetGraphicParams();
+                            setImageDims();
+                            targetCounts();
+                            if (renderings[0].data.layer != null) {
+                                setDefaultLayer(renderings[0].data.layer);
+                            }
+                            else{
+                                presentLayer = -1;
+                            }
                         }
                         else{
                             // this is where followup response is handled

--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -1313,11 +1313,10 @@ public class DataAndMethods {
             call = makereq.makeMapRequest(req);
         }
 
-        /*
 
 
-        Log.d("REQUEST", String.valueOf(jsonObject.has("latitude")));
-         */
+        // Log.d("REQUEST", String.valueOf(history.temp_request.getJSONObject("followup")));
+
 
         // need to make a separate function so that 'image' is not replaced
         makeServerCall(call);

--- a/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024 IMAGE Project, Shared Reality Lab, McGill University
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * and our Additional Terms along with this program.
+ * If not, see <https://github.com/Shared-Reality-Lab/IMAGE-Monarch/LICENSE>.
+ */
 package ca.mcgill.a11y.image;
 
 import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
@@ -14,6 +30,7 @@ import android.view.GestureDetector;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
+import org.json.JSONException;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -25,6 +42,7 @@ import javax.xml.xpath.XPathExpressionException;
 public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener, MediaPlayer.OnCompletionListener {
     Intent intent;
     String query;
+
     Integer state;
 
     Integer[] region = null;
@@ -42,12 +60,18 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
         state++;
         switch(state){
             case 0:
-                Log.d("QUERY", query);
-                DataAndMethods.speaker("Query received: "+query+" ...Click on top left corner of region of interest or press confirm to query without selection");
+                // Log.d("QUERY", query);
+                try {
+                    brailleServiceObj.display(DataAndMethods.getBitmaps(DataAndMethods.getfreshDoc(), DataAndMethods.presentLayer, false));
+                } catch (IOException | XPathExpressionException | ParserConfigurationException |
+                         SAXException e) {
+                    throw new RuntimeException(e);
+                }
+                DataAndMethods.speaker("Query received: "+query+" ...Double click on top left corner of region of interest or press confirm to query without selection");
                 break;
             case 1:
                 //Log.d("STATE", "State 1");
-                DataAndMethods.speaker("Click on bottom right corner of region of interest or press confirm to proceed without selection. Press cancel to return");
+                DataAndMethods.speaker("Double click on bottom right corner of region of interest or press confirm to proceed without selection. Press cancel to return");
                 break;
             case 2:
                 //Log.d("STATE", "State 2");
@@ -65,14 +89,18 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                     case 0:
                     case 2:
                         // Make request without region
-                        DataAndMethods.sendFollowUpQuery(query, region);
+                        try {
+                            DataAndMethods.sendFollowUpQuery(query, region);
+                        } catch (JSONException | IOException e) {
+                            throw new RuntimeException(e);
+                        }
                         finish();
                         break;
                     default:
                         DataAndMethods.pingsPlayer(R.raw.image_error);
                         break;
                 }
-                return false;
+                return true;
             case "CANCEL":
                 switch(state){
                     case 1:
@@ -84,7 +112,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                         DataAndMethods.pingsPlayer(R.raw.image_error);
                         break;
                 }
-                return false;
+                return true;
             default:
                 Log.d("KEY EVENT", event.toString());
                 return false;
@@ -97,36 +125,35 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
             int action = event.getActionMasked();
             if (action==MotionEvent.ACTION_UP)
             {
+                ArrayList<String[][]> tags = DataAndMethods.tags;
                 Integer [] pins=DataAndMethods.pinCheck(event.getX(), event.getY());
-                switch(state){
-                    case 0:
-                        region = new Integer[]{0, 0, 0, 0};
-                        region[0] = pins[0];
-                        region[1]=pins[1];
-                        updateState();
-                        break;
-                    case 1:
-                        region[2] = pins[0];
-                        region[3] = pins[1];
-                        // Need to check for valid region here; Also set region to null if it is not...
-                        if (DataAndMethods.validateRegion(region)){
-                            try {
-                                showRegion(region);
-                            } catch (XPathExpressionException | ParserConfigurationException |
-                                     IOException | SAXException e) {
-                                Log.d("EXCEPTION", String.valueOf(e));
-                                throw new RuntimeException(e);
-                            }
-                            updateState();
-                        }else{
-                            //DataAndMethods.speaker("Invalid region!");
-                            region = null;
-                            state = -1;
-                            updateState();
+                try{
+                    // Check if zooming mode is enabled
+                    if (DataAndMethods.zoomingIn || DataAndMethods.zoomingOut){
+                        DataAndMethods.zoom(pins, "Exploration");
+                    }
+                    else {
+                        Log.d("TAGS", "ACCESS TTS");
+                        // Speak out label tags based on finger location and ping when detailed description is available
+                        if ((tags.get(1)[pins[1]][pins[0]] != null) && (tags.get(1)[pins[1]][pins[0]].trim().length() > 0)) {
+                            //Log.d("CHECKING!", tags.get(1)[pins[1]][pins[0]]);
+                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]], "ping");
+                        } else {
+                            //Log.d("CHECKING!", tags.get(0)[pins[1]][pins[0]]);
+                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]]);
                         }
-                        break;
-                    default:
-                        break;
+                    }
+                }
+                catch(RuntimeException ex){
+                    Log.d("TTS ERROR", String.valueOf(ex));
+                } catch (XPathExpressionException e) {
+                    throw new RuntimeException(e);
+                } catch (ParserConfigurationException e) {
+                    throw new RuntimeException(e);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                } catch (SAXException e) {
+                    throw new RuntimeException(e);
                 }
             }
         }
@@ -154,6 +181,14 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
 
     @Override
     public void onLongPress(MotionEvent event) {
+        Integer [] pins= DataAndMethods.pinCheck(event.getX(), event.getY());
+        try{
+            // Speak out detailed description based on finger location
+            DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]]);
+        }
+        catch(RuntimeException ex){
+            Log.d("TTS ERROR", String.valueOf(ex));
+        }
         Log.d("GESTURE!", "onLongPress: " + event.toString());
 
     }
@@ -179,6 +214,37 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
     @Override
     public boolean onDoubleTap(MotionEvent event) {
         Log.d("GESTURE!", "onDoubleTap: " + event.toString());
+        Integer [] pins=DataAndMethods.pinCheck(event.getX(), event.getY());
+        switch(state){
+            case 0:
+                region = new Integer[]{0, 0, 0, 0};
+                region[0] = pins[0];
+                region[1]=pins[1];
+                updateState();
+                break;
+            case 1:
+                region[2] = pins[0];
+                region[3] = pins[1];
+                // Need to check for valid region here; Also set region to null if it is not...
+                if (DataAndMethods.validateRegion(region)){
+                    try {
+                        showRegion(region);
+                    } catch (XPathExpressionException | ParserConfigurationException |
+                             IOException | SAXException e) {
+                        Log.d("EXCEPTION", String.valueOf(e));
+                        throw new RuntimeException(e);
+                    }
+                    updateState();
+                }else{
+                    //DataAndMethods.speaker("Invalid region!");
+                    region = null;
+                    state = -1;
+                    updateState();
+                }
+                break;
+            default:
+                break;
+        }
         return true;
     }
 
@@ -214,12 +280,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
             return false;
         };
         brailleServiceObj.registerMotionEventHandler(DataAndMethods.handler);
-        try {
-            brailleServiceObj.display(DataAndMethods.getBitmaps(DataAndMethods.getfreshDoc(), DataAndMethods.presentLayer, false));
-        } catch (IOException | XPathExpressionException | ParserConfigurationException |
-                 SAXException e) {
-            throw new RuntimeException(e);
-        }
+
         state = -1;
         updateState();
         super.onResume();

--- a/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
@@ -63,11 +63,9 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
             case "OK":
                 switch(state){
                     case 0:
-                        // Make request without region
-                        finish();
-                        break;
                     case 2:
-                        // Make request with region
+                        // Make request without region
+                        DataAndMethods.sendFollowUpQuery(query, region);
                         finish();
                         break;
                     default:

--- a/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
@@ -1,0 +1,236 @@
+package ca.mcgill.a11y.image;
+
+import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
+import static ca.mcgill.a11y.image.DataAndMethods.showRegion;
+
+import androidx.core.view.GestureDetectorCompat;
+
+import android.content.Intent;
+import android.media.MediaPlayer;
+import android.os.BrailleDisplay;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.GestureDetector;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+
+public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener, MediaPlayer.OnCompletionListener {
+    Intent intent;
+    String query;
+    Integer state;
+
+    Integer[] region = null;
+    private GestureDetectorCompat mDetector;
+    private BrailleDisplay brailleServiceObj = null;
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        Log.d("ACTIVITY", "FollowUpQuery Created");
+        super.onCreate(savedInstanceState);
+        brailleServiceObj = DataAndMethods.brailleServiceObj;
+
+    }
+
+    public void updateState() {
+        state++;
+        switch(state){
+            case 0:
+                Log.d("QUERY", query);
+                DataAndMethods.speaker("Query received: "+query+" ...Click on top left corner of region of interest or press confirm to query without selection");
+                break;
+            case 1:
+                //Log.d("STATE", "State 1");
+                DataAndMethods.speaker("Click on bottom right corner of region of interest or press confirm to proceed without selection. Press cancel to return");
+                break;
+            case 2:
+                //Log.d("STATE", "State 2");
+                DataAndMethods.speaker("Press confirm to query for selected region. Press cancel to return to region selection");
+                break;
+        }
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        super.onKeyDown(keyCode, event);
+        switch (keyMapping.getOrDefault(keyCode, "default")) {
+            case "OK":
+                switch(state){
+                    case 0:
+                        // Make request without region
+                        finish();
+                        break;
+                    case 2:
+                        // Make request with region
+                        finish();
+                        break;
+                    default:
+                        DataAndMethods.pingsPlayer(R.raw.image_error);
+                        break;
+                }
+                return false;
+            case "CANCEL":
+                switch(state){
+                    case 1:
+                    case 2:
+                        state = -1;
+                        updateState();
+                        break;
+                    default:
+                        DataAndMethods.pingsPlayer(R.raw.image_error);
+                        break;
+                }
+                return false;
+            default:
+                Log.d("KEY EVENT", event.toString());
+                return false;
+        }
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event){
+        if (this.mDetector.onTouchEvent(event)) {
+            int action = event.getActionMasked();
+            if (action==MotionEvent.ACTION_UP)
+            {
+                Integer [] pins=DataAndMethods.pinCheck(event.getX(), event.getY());
+                switch(state){
+                    case 0:
+                        region = new Integer[]{0, 0, 0, 0};
+                        region[0] = pins[0];
+                        region[1]=pins[1];
+                        updateState();
+                        break;
+                    case 1:
+                        region[2] = pins[0];
+                        region[3] = pins[1];
+                        // Need to check for valid region here; Also set region to null if it is not...
+                        if (DataAndMethods.validateRegion(region)){
+                            try {
+                                showRegion(region);
+                            } catch (XPathExpressionException | ParserConfigurationException |
+                                     IOException | SAXException e) {
+                                Log.d("EXCEPTION", String.valueOf(e));
+                                throw new RuntimeException(e);
+                            }
+                            updateState();
+                        }else{
+                            //DataAndMethods.speaker("Invalid region!");
+                            region = null;
+                            state = -1;
+                            updateState();
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void onCompletion(MediaPlayer mediaPlayer) {
+        mediaPlayer.release();
+    }
+
+    @Override
+    public boolean onDown(MotionEvent event) {
+        Log.d("GESTURE!","onDown: " + event.toString());
+
+        return true;
+    }
+
+    @Override
+    public boolean onFling(MotionEvent event1, MotionEvent event2,
+                           float velocityX, float velocityY) {
+        Log.d("GESTURE!", "onFling: " + event1.toString() + event2.toString());
+        return true;
+    }
+
+    @Override
+    public void onLongPress(MotionEvent event) {
+        Log.d("GESTURE!", "onLongPress: " + event.toString());
+
+    }
+
+    @Override
+    public boolean onScroll(MotionEvent event1, MotionEvent event2, float distanceX,
+                            float distanceY) {
+        Log.d("GESTURE!", "onScroll: " + event1.toString() + event2.toString());
+        return true;
+    }
+
+    @Override
+    public void onShowPress(MotionEvent event) {
+        Log.d("GESTURE!", "onShowPress: " + event.toString());
+    }
+
+    @Override
+    public boolean onSingleTapUp(MotionEvent event) {
+        Log.d("GESTURE!", "onSingleTapUp: " + event.toString());
+        return true;
+    }
+
+    @Override
+    public boolean onDoubleTap(MotionEvent event) {
+        Log.d("GESTURE!", "onDoubleTap: " + event.toString());
+        return true;
+    }
+
+    @Override
+    public boolean onDoubleTapEvent(MotionEvent event) {
+        Log.d("GESTURE!", "onDoubleTapEvent: " + event.toString());
+        return true;
+    }
+
+    @Override
+    public boolean onSingleTapConfirmed(MotionEvent event) {
+        Log.d("GESTURE!", "onSingleTapConfirmed: " + event.toString());
+        return true;
+    }
+
+    @Override
+    protected void onResume() {
+        Log.d("ACTIVITY", "FollowUpQuery Resumed");
+        intent = getIntent();
+        query = intent.getStringExtra("query");
+
+        mDetector = new GestureDetectorCompat(this,this);
+        mDetector.setOnDoubleTapListener(this);
+
+        DataAndMethods.handler = e -> {
+                try{
+                    onTouchEvent(e);
+                }
+                catch(RuntimeException ex){
+                    Log.d("MOTION EVENT", String.valueOf(ex));
+                }
+
+            return false;
+        };
+        brailleServiceObj.registerMotionEventHandler(DataAndMethods.handler);
+        try {
+            brailleServiceObj.display(DataAndMethods.getBitmaps(DataAndMethods.getfreshDoc(), DataAndMethods.presentLayer, false));
+        } catch (IOException | XPathExpressionException | ParserConfigurationException |
+                 SAXException e) {
+            throw new RuntimeException(e);
+        }
+        state = -1;
+        updateState();
+        super.onResume();
+    }
+    @Override
+    protected void onPause() {
+        Log.d("ACTIVITY", "FollowUpQuery Paused");
+        DataAndMethods.presentLayer--;
+        brailleServiceObj.unregisterMotionEventHandler(DataAndMethods.handler);
+        super.onPause();
+    }
+}

--- a/app/src/main/java/ca/mcgill/a11y/image/History.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/History.java
@@ -1,0 +1,51 @@
+package ca.mcgill.a11y.image;
+
+import android.util.Log;
+
+import com.google.gson.Gson;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.Console;
+
+// keeping track of requests history
+public class History{
+    String type;
+    JSONObject request;
+    String temp_type;
+    JSONObject temp_request;
+
+    String response;
+
+    public void updateHistory(Object req) throws JSONException {
+        Gson gson = new Gson();
+        String json = gson.toJson(req);
+        JSONObject jsonObject = new JSONObject(json);
+        if (jsonObject.has("graphic")){
+            this.temp_type = "Photo";
+        } else if (jsonObject.has("coordinates")) {
+            this.temp_type = "Map";
+        }
+        this.temp_request = jsonObject;
+    }
+    public void setHistory(Boolean set){
+        if (set){
+            this.type = this.temp_type;
+            this.request = this.temp_request;
+        }
+        this.temp_type = null;
+        this.temp_request = null;
+        // Log.d("HISTORY", history() );
+    }
+
+    public String history(){
+        return this.type + ", " + this.request;
+    }
+
+    public void setResponse(String response){
+        this.response = response;
+    }
+
+
+}

--- a/app/src/main/java/ca/mcgill/a11y/image/History.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/History.java
@@ -39,9 +39,9 @@ public class History{
         // Log.d("HISTORY", history() );
     }
 
-    public String history(){
-        return this.type + ", " + this.request;
-    }
+    // public String history(){
+    //    return this.type + ", " + this.request;
+    // }
 
     public void setResponse(String response){
         this.response = response;

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/BasicPhotoMapRenderer.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/BasicPhotoMapRenderer.java
@@ -22,6 +22,7 @@ import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
 
 import androidx.core.view.GestureDetectorCompat;
 
+import android.content.Intent;
 import android.media.MediaPlayer;
 import android.os.BrailleDisplay;
 import android.os.Bundle;
@@ -45,6 +46,7 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
     private BrailleDisplay brailleServiceObj = null;
 
     private GestureDetectorCompat mDetector;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -59,17 +61,17 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
         switch (keyMapping.getOrDefault(keyCode, "default")) {
             case "OK":
                 DataAndMethods.displayGraphic(DataAndMethods.confirmButton, "Exploration");
-                return false;
+                return true;
             case "CANCEL":
                 DataAndMethods.displayGraphic(DataAndMethods.backButton, "Exploration");
-                return false;
+                return true;
             case "MENU":
                 DataAndMethods.pingsPlayer(R.raw.blip);
-                DataAndMethods.speechRecognizer.startListening(DataAndMethods.speechRecognizerIntent.putExtra("Activity", getLocalClassName()));
-                return false;
+                DataAndMethods.speechRecognizer.startListening(DataAndMethods.speechRecognizerIntent);
+                return true;
             default:
                 Log.d("KEY EVENT", event.toString());
-                return false;
+                return true;
         }
     }
 

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/BasicPhotoMapRenderer.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/BasicPhotoMapRenderer.java
@@ -60,9 +60,12 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
             case "OK":
                 DataAndMethods.displayGraphic(DataAndMethods.confirmButton, "Exploration");
                 return false;
-
             case "CANCEL":
                 DataAndMethods.displayGraphic(DataAndMethods.backButton, "Exploration");
+                return false;
+            case "MENU":
+                DataAndMethods.pingsPlayer(R.raw.blip);
+                DataAndMethods.speechRecognizer.startListening(DataAndMethods.speechRecognizerIntent.putExtra("Activity", getLocalClassName()));
                 return false;
             default:
                 Log.d("KEY EVENT", event.toString());
@@ -72,7 +75,7 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
 
     @Override
     public void onCompletion(MediaPlayer mediaPlayer) {
-
+        mediaPlayer.release();
     }
     @Override
     public boolean onTouchEvent(MotionEvent event){

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
@@ -67,10 +67,11 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
 
         brailleServiceObj = DataAndMethods.brailleServiceObj;
         // DataAndMethods.initialize(brailleServiceObj, getApplicationContext(), findViewById(android.R.id.content));
+        DataAndMethods.image = null;
         DataAndMethods.update.observe(this,new Observer<Boolean>() {
             @Override
             public void onChanged(Boolean changedVal) {
-                if (changedVal){
+                if (changedVal && DataAndMethods.image != null){
                     displayGraphic(confirmButton, "Exploration");
                 }
             }
@@ -100,11 +101,13 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
                     return true;
 
                 case "OK":
-                    DataAndMethods.displayGraphic(confirmButton, "Exploration");
+                    if (DataAndMethods.image!= null)
+                        DataAndMethods.displayGraphic(confirmButton, "Exploration");
                     return false;
 
                 case "CANCEL":
-                    DataAndMethods.displayGraphic(backButton, "Exploration");
+                    if (DataAndMethods.image!= null)
+                        DataAndMethods.displayGraphic(backButton, "Exploration");
                     return false;
                 default:
                     Log.d("KEY EVENT", event.toString());

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/Guidance.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/Guidance.java
@@ -64,10 +64,11 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
 
         brailleServiceObj = DataAndMethods.brailleServiceObj;
         // DataAndMethods.initialize(brailleServiceObj, getApplicationContext(), findViewById(android.R.id.content));
+        DataAndMethods.image = null;
         DataAndMethods.update.observe(this,new Observer<Boolean>() {
             @Override
             public void onChanged(Boolean changedVal) {
-                if (changedVal){
+                if (changedVal && DataAndMethods.image != null){
                     displayGraphic(confirmButton, "Guidance");
                 }
             }
@@ -97,11 +98,13 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
                     return true;
 
                 case "OK":
-                    DataAndMethods.displayGraphic(confirmButton, "Guidance");
+                    if (DataAndMethods.image!= null)
+                        DataAndMethods.displayGraphic(confirmButton, "Guidance");
                     return false;
 
                 case "CANCEL":
-                    DataAndMethods.displayGraphic(backButton, "Guidance");
+                    if (DataAndMethods.image!= null)
+                        DataAndMethods.displayGraphic(backButton, "Guidance");
                     return false;
                 default:
                     Log.d("KEY EVENT", event.toString());

--- a/app/src/main/java/ca/mcgill/a11y/image/request_formats/BaseRequestFormat.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/request_formats/BaseRequestFormat.java
@@ -16,9 +16,15 @@
  */
 package ca.mcgill.a11y.image.request_formats;
 
+import android.util.Log;
+
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 
+import org.json.JSONException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.UUID;
 
 // base request schema extended for requests to IMAGE-server
@@ -37,4 +43,49 @@ public class BaseRequestFormat {
     private String[] rends= new String[]{"ca.mcgill.a11y.image.renderer.TactileSVG"};
     @SerializedName("preprocessors")
     private JsonObject preps= new JsonObject();
+
+    // Follow - up query fields
+    @SerializedName("route")
+    private String route=null;
+
+    @SerializedName("followup")
+    private BaseRequestFormat.FollowUp followup= null;
+
+    public void setRoute(String route) throws JSONException {
+        this.route= route;
+    }
+
+    public class FollowUp{
+        @SerializedName("query")
+        String query;
+        @SerializedName("focus")
+        Float[] focus;
+        @SerializedName("previous")
+        //BaseRequestFormat.PreviousReqs[] previous= null;
+        String[][] previous = null;
+    }
+    public void setFollowupValues(String query, Float[] focus) throws JSONException {
+        this.followup = new BaseRequestFormat.FollowUp();
+        this.followup.query = query;
+        this.followup.focus = focus;
+    }
+
+    public static class PreviousReqs{
+        String query;
+        String response;
+
+        public PreviousReqs(String query, String response){
+            this.query = query;
+            this.response = response;
+        }
+    }
+
+    public void setPrevious(String[][] previous){
+        this.followup.previous = previous;
+        //Log.d("SETTING PREVIOUS", Arrays.toString(this.followup.previous[0]));
+    }
+
+    public void optionalSetRenderers(String[] rends) throws JSONException {
+        this.rends = rends;
+    }
 }

--- a/app/src/main/java/ca/mcgill/a11y/image/request_formats/BaseRequestFormat.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/request_formats/BaseRequestFormat.java
@@ -61,23 +61,12 @@ public class BaseRequestFormat {
         @SerializedName("focus")
         Float[] focus;
         @SerializedName("previous")
-        //BaseRequestFormat.PreviousReqs[] previous= null;
         String[][] previous = null;
     }
     public void setFollowupValues(String query, Float[] focus) throws JSONException {
         this.followup = new BaseRequestFormat.FollowUp();
         this.followup.query = query;
         this.followup.focus = focus;
-    }
-
-    public static class PreviousReqs{
-        String query;
-        String response;
-
-        public PreviousReqs(String query, String response){
-            this.query = query;
-            this.response = response;
-        }
     }
 
     public void setPrevious(String[][] previous){

--- a/app/src/main/java/ca/mcgill/a11y/image/request_formats/MakeRequest.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/request_formats/MakeRequest.java
@@ -38,4 +38,5 @@ public interface MakeRequest {
     @Headers("Content-Type: application/json")
     @POST("render/")
     Call<ResponseFormat> makeMapRequest(@Body MapRequestFormat req);
+
 }

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/ClassroomSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/ClassroomSelector.java
@@ -148,13 +148,13 @@ public class ClassroomSelector extends BaseActivity implements MediaPlayer.OnCom
     protected void onResume() {
         Log.d("ACTIVITY", "Classroom Selector Resumed");
         DataAndMethods.speaker("Classroom Selector");
-        startService(new Intent(getApplicationContext(), PollingService.class));
+        //startService(new Intent(getApplicationContext(), PollingService.class));
         super.onResume();
     }
     @Override
     protected void onPause() {
         Log.d("ACTIVITY", "Exploration Paused");
-        stopService(new Intent(getApplicationContext(), PollingService.class));
+        //stopService(new Intent(getApplicationContext(), PollingService.class));
         super.onPause();
     }
 

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/ModeSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/ModeSelector.java
@@ -125,6 +125,7 @@ public class ModeSelector extends BaseActivity implements MediaPlayer.OnCompleti
     protected void onResume() {
         Log.d("ACTIVITY", "ModeSelector Resumed");
         DataAndMethods.speaker("Mode selector");
+        DataAndMethods.image = null;
         update.setValue(false);
         super.onResume();
     }


### PR DESCRIPTION
It adds features that allow a Monarch user to ask a question verbally and optionally indicate a region of interest about the experience they have received. The Monarch application generates a follow-up request which includes the spoken query as text,  the ROI if available and a history of past follow up queries for context.

As commented in #50, some additional work needs to be done on the client application to handle the 'follow up' responses.

Closes #50 