### PR TITLE
Working follow up query app version with single returned reponse for follow up query

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,9 @@
             android:name=".FollowUpQuery"
             android:exported="false" />
         <activity
+            android:name=".ShowFollowUp"
+            android:exported="false" />
+        <activity
             android:name=".RendererBaseActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/ca/mcgill/a11y/image/BaseActivity.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/BaseActivity.java
@@ -41,6 +41,7 @@ import android.os.Bundle;
 import android.speech.RecognitionListener;
 import android.speech.RecognizerIntent;
 import android.speech.SpeechRecognizer;
+import android.speech.tts.TextToSpeech;
 import android.speech.tts.Voice;
 import android.util.Log;
 import android.view.GestureDetector;
@@ -122,23 +123,23 @@ public class BaseActivity extends AppCompatActivity {
                 case "ZOOM OUT":
                     Log.d("KEY EVENT", event.toString());
                     if (!DataAndMethods.zoomingOut) {
-                        DataAndMethods.speaker("Zoom mode enabled");
+                        DataAndMethods.speaker("Zoom mode enabled", TextToSpeech.QUEUE_FLUSH);
                         DataAndMethods.zoomingOut = true;
                         DataAndMethods.zoomingIn = false;
                     } else {
                         DataAndMethods.zoomingOut = false;
-                        DataAndMethods.speaker("Zoom mode disabled");
+                        DataAndMethods.speaker("Zoom mode disabled", TextToSpeech.QUEUE_FLUSH);
                     }
                     return true;
                 case "ZOOM IN":
                     Log.d("KEY EVENT", event.toString());
                     if (!DataAndMethods.zoomingIn) {
-                        DataAndMethods.speaker("Zoom mode enabled");
+                        DataAndMethods.speaker("Zoom mode enabled", TextToSpeech.QUEUE_FLUSH);
                         DataAndMethods.zoomingIn = true;
                         DataAndMethods.zoomingOut = false;
                     } else {
                         DataAndMethods.zoomingIn = false;
-                        DataAndMethods.speaker("Zoom mode disabled");
+                        DataAndMethods.speaker("Zoom mode disabled", TextToSpeech.QUEUE_FLUSH);
                     }
                     return true;
                 case "DPAD UP":

--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -165,6 +165,7 @@ public class DataAndMethods {
     public static MutableLiveData<Boolean> update = new MutableLiveData<>();
     public static Boolean followup = false;
 
+    public static Boolean titleRead = true;
     public static String tempImage = "";
     // mapping of keyCodes
     public static Map<Integer, String> keyMapping = new HashMap<Integer, String>() {{
@@ -402,7 +403,13 @@ public class DataAndMethods {
     // get present layer and the description tags from the doc
     public static byte[][] getBitmaps(Document doc, int presentLayer, boolean readCaption) throws IOException, XPathExpressionException {
         //Log.d("LAYER!", String.valueOf(presentLayer));
+        String caption = null;
         XPath xPath = XPathFactory.newInstance().newXPath();
+        // get the caption from the title node
+        Element title = ((Element) ((NodeList) xPath.evaluate("//title", doc, XPathConstants.NODESET)).item(0));
+        if (title!=null){
+            caption = title.getTextContent();
+        }
         // get list of layers; Uses default ordering which is expected to be 'document order' but the return type is node-set which is unordered!
         NodeList nodeslist = (NodeList)xPath.evaluate("//*[self::*[@data-image-layer] and not(ancestor::metadata)]", doc, XPathConstants.NODESET);
         //Log.d("XPATH", String.valueOf(nodeslist.getLength()));
@@ -434,7 +441,16 @@ public class DataAndMethods {
                     //Log.d("GETTING TAGS", "Otherwise here!");
                 }
                 if (readCaption) {
-                    speaker("Layer: " + tag, TextToSpeech.QUEUE_FLUSH);
+                    if(i==0 && caption!=null && titleRead){
+                        // Read the caption along with layer tag for the first layer
+                        speaker(caption + ". Layer: " + tag, TextToSpeech.QUEUE_FLUSH);
+                    }
+                    else{
+                        speaker("Layer: "+tag, TextToSpeech.QUEUE_FLUSH);
+                    }
+                }
+                if (!titleRead){
+                    titleRead = true;
                 }
             }
         }
@@ -673,7 +689,8 @@ public class DataAndMethods {
         PhotoRequestFormat req= new PhotoRequestFormat();
         req.setValues(base64, dims);*/
         PhotoRequestFormat req = createPhotoRequest(folderName);
-        Retrofit retrofit = requestBuilder(60, 60, "https://image.a11y.mcgill.ca/");
+        Retrofit retrofit = requestBuilder(60, 60, "https://unicorn.cim.mcgill.ca/image/");
+                //"https://image.a11y.mcgill.ca/");
 
         MakeRequest makereq= retrofit.create(MakeRequest.class);
         Call<ResponseFormat> call= makereq.makePhotoRequest(req);

--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -70,6 +70,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -162,6 +163,9 @@ public class DataAndMethods {
     static final int DISK_CACHE_SIZE = 10 * 1024 * 1024;
     //tracker to check whether new data has been received after server call
     public static MutableLiveData<Boolean> update = new MutableLiveData<>();
+    public static Boolean followup = false;
+
+    public static String tempImage = "";
     // mapping of keyCodes
     public static Map<Integer, String> keyMapping = new HashMap<Integer, String>() {{
         put(421, "UP");
@@ -276,9 +280,9 @@ public class DataAndMethods {
                     Log.d("SPEECHREC", String.valueOf(i));
                     switch (i) {
                         case SpeechRecognizer.ERROR_NO_MATCH:
-                            DataAndMethods.speaker("Failed to recognize text");
+                            DataAndMethods.speaker("Failed to recognize text", TextToSpeech.QUEUE_FLUSH);
                         default:
-                            DataAndMethods.speaker("Error occurred during speech recognition");
+                            DataAndMethods.speaker("Error occurred during speech recognition", TextToSpeech.QUEUE_FLUSH);
                     }
                 }
 
@@ -303,6 +307,17 @@ public class DataAndMethods {
         }
     }
 
+    public static void onShowFollowUp() throws IOException, XPathExpressionException, ParserConfigurationException, SAXException {
+        Intent myIntent = new Intent(DataAndMethods.context, ShowFollowUp.class);
+        myIntent.putExtra("image", image);
+        myIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        byte[] data = (tempImage.replaceFirst("data:.+,", "")).getBytes("UTF-8");
+        data = Base64.decode(data, Base64.DEFAULT);
+        image = new String(data, "UTF-8");
+        resetGraphicParams();
+        setImageDims();
+        DataAndMethods.context.startActivity(myIntent);
+    }
 
     // handle voice recognition results()
     public static void onVoiceRecognitionResults(String results){
@@ -312,7 +327,6 @@ public class DataAndMethods {
             myIntent.putExtra("query", results);
             myIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             DataAndMethods.context.startActivity(myIntent);
-
         }else
             Log.d("onVoiceRecognitionResults", "NOT HANDLED YET!");
     }
@@ -394,19 +408,20 @@ public class DataAndMethods {
         //Log.d("XPATH", String.valueOf(nodeslist.getLength()));
         Integer layerCount=nodeslist.getLength();
         //Log.d("PRESENT LAYER", DataAndMethods.presentLayer+","+layerCount);
-        if (DataAndMethods.presentLayer>= layerCount+1)
-            DataAndMethods.presentLayer= 0;
-        else if (DataAndMethods.presentLayer<0)
-            DataAndMethods.presentLayer= layerCount;
+        if (presentLayer>= layerCount+1)
+            presentLayer= 0;
+        else if (presentLayer<0)
+            presentLayer= layerCount;
+        DataAndMethods.presentLayer = presentLayer;
         //Log.d("PRESENT LAYER", DataAndMethods.presentLayer+","+layerCount);
         for(int i = 0 ; i < nodeslist.getLength() ; i ++) {
             Node node = nodeslist.item(i);
             // hide layers which are not the present layer
-            if (i!= DataAndMethods.presentLayer && DataAndMethods.presentLayer!=layerCount) {
+            if (i!= presentLayer && presentLayer!=layerCount) {
                 ((Element)node).setAttribute("display","none");
             }
             // TTS output of layer description
-            if (i==DataAndMethods.presentLayer){
+            if (i==presentLayer){
                 //Log.d("GETTING TAGS", String.valueOf(nodeslist.getLength()));
                 String tag;
                 //Log.d("GETTING TAGS", node.getNodeName());
@@ -419,12 +434,12 @@ public class DataAndMethods {
                     //Log.d("GETTING TAGS", "Otherwise here!");
                 }
                 if (readCaption) {
-                    speaker("Layer: " + tag);
+                    speaker("Layer: " + tag, TextToSpeech.QUEUE_FLUSH);
                 }
             }
         }
         //If there is no tag as a layer, hide elements unless the full image is to be shown
-        if (DataAndMethods.presentLayer!=layerCount){
+        if (presentLayer!=layerCount){
 
             nodeslist=(NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@data-image-layer]) and not(descendant::*[@data-image-layer])] ", doc, XPathConstants.NODESET);
             for(int i = 0 ; i < nodeslist.getLength() ; i ++) {
@@ -433,7 +448,7 @@ public class DataAndMethods {
             }
         }
         else if (readCaption){
-            speaker("Full image");
+            speaker("Full image", TextToSpeech.QUEUE_FLUSH);
         }
 
         NodeList detail= (NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@display]) and not(descendant::*[@display]) and (self::*[@data-image-zoom])]", doc, XPathConstants.NODESET);
@@ -477,7 +492,7 @@ public class DataAndMethods {
         String tag = "";
         XPath xPath = XPathFactory.newInstance().newXPath();
         if (targetCount ==0){
-            speaker("No guidance mode available");
+            speaker("No guidance mode available", TextToSpeech.QUEUE_FLUSH);
             return data;
         }
         else if (presentTarget<=0 ){
@@ -522,7 +537,7 @@ public class DataAndMethods {
             //Log.d("GETTING TAGS",((Element)node).getAttribute("aria-label"));
         }
         if (readCaption){
-        speaker("Layer: " + tag);}
+        speaker("Layer: " + tag, TextToSpeech.QUEUE_FLUSH);}
 
         byte[] target = docToBitmap(doc);
 
@@ -830,7 +845,24 @@ public class DataAndMethods {
                         else{
                             // this is where followup response is handled
                             //Log.d("FOLLOW UP", "Found followup field");
-                            history.setResponse("This is the followup query response");
+                            String furesponse = "";
+                            //for (int i=0; i< renderings.length; i++){
+                            if (renderings[0].type_id.contains("Text")){
+                                furesponse = renderings[0].data.text;
+                                speaker(furesponse, TextToSpeech.QUEUE_ADD);
+                            }
+                            else if(renderings[0].type_id.contains("TactileSVG")){
+                                furesponse = renderings[0].data.graphic;
+                                tempImage = furesponse;
+                                speaker("Tactile response received. Press confirm to view it. Press cancel to ignore", TextToSpeech.QUEUE_ADD);
+                                followup = true;
+                            }
+                            else{
+                                furesponse = "Response received in type that is not handled yet";
+                            }
+                                // Log.d("RESPONSE", furesponse);
+                            //}
+                            history.setResponse(furesponse);
                         }
                         history.setHistory(true);
                         pingsPlayer(R.raw.image_results_arrived);
@@ -1012,7 +1044,7 @@ public class DataAndMethods {
         }
         else{
             if (zoomVal <= 100){
-                speaker("Oops! Cannot zoom out further");
+                speaker("Oops! Cannot zoom out further", TextToSpeech.QUEUE_FLUSH);
             }
             else {
                 zoomVal-= 25;
@@ -1165,8 +1197,8 @@ public class DataAndMethods {
     }
 
     // TTS speaker. Probably needs a little more work on flushing and/or selecting whether to continue playing
-    public static void speaker(String text, String... utterId){
-        tts.speak (text, TextToSpeech.QUEUE_FLUSH, null, utterId.length > 0 ? utterId[0]  : "000000");
+    public static void speaker(String text, int queue, String... utterId){
+        tts.speak (text, queue, null, utterId.length > 0 ? utterId[0]  : "000000");
         return;
     }
 
@@ -1247,8 +1279,8 @@ public class DataAndMethods {
     // make follow up query to server
     public static void sendFollowUpQuery(String query, Integer[] region) throws JSONException, IOException {
         Float[] focus = null;
-        Retrofit retrofit = requestBuilder(60, 60, // "https://unicorn.cim.mcgill.ca/image/" );
-                "https://image.a11y.mcgill.ca/");
+        Retrofit retrofit = requestBuilder(60, 60, "https://unicorn.cim.mcgill.ca/image/" );
+                //"https://image.a11y.mcgill.ca/");
         MakeRequest makereq= retrofit.create(MakeRequest.class);
         Call<ResponseFormat> call = null;
 
@@ -1292,6 +1324,9 @@ public class DataAndMethods {
             req.setValues(base64, dims);
             //Log.d("HISTORY", history.type);
             req.setFollowupValues(query,focus);
+            req.setRoute("followup");
+            req.optionalSetRenderers(new String[] {"ca.mcgill.a11y.image.renderer.Text",
+                    "ca.mcgill.a11y.image.renderer.TactileSVG"});
             if (history.request.has("followup")){
                 String[][] previous = setPrevious();
                 req.setPrevious(previous);
@@ -1305,6 +1340,9 @@ public class DataAndMethods {
             Double lon = history.request.getJSONObject("coordinates").getDouble("longitude");
             req.setValues(lat, lon);
             req.setFollowupValues(query,focus);
+            req.setRoute("followup");
+            req.optionalSetRenderers(new String[] {"ca.mcgill.a11y.image.renderer.Text",
+                    "ca.mcgill.a11y.image.renderer.TactileSVG"});
             if (history.request.has("followup")){
                 String[][] previous = setPrevious();
                 req.setPrevious(previous);

--- a/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
@@ -18,6 +18,7 @@ package ca.mcgill.a11y.image;
 
 import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
 import static ca.mcgill.a11y.image.DataAndMethods.showRegion;
+import static ca.mcgill.a11y.image.DataAndMethods.titleRead;
 
 import androidx.core.view.GestureDetectorCompat;
 
@@ -95,6 +96,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                         } catch (JSONException | IOException e) {
                             throw new RuntimeException(e);
                         }
+                        titleRead = false;
                         finish();
                         break;
                     default:

--- a/app/src/main/java/ca/mcgill/a11y/image/ShowFollowUp.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/ShowFollowUp.java
@@ -17,9 +17,9 @@
 package ca.mcgill.a11y.image;
 
 import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
+import static ca.mcgill.a11y.image.DataAndMethods.resetGraphicParams;
+import static ca.mcgill.a11y.image.DataAndMethods.setImageDims;
 import static ca.mcgill.a11y.image.DataAndMethods.showRegion;
-
-import androidx.core.view.GestureDetectorCompat;
 
 import android.content.Intent;
 import android.media.MediaPlayer;
@@ -31,6 +31,8 @@ import android.view.GestureDetector;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
+import androidx.core.view.GestureDetectorCompat;
+
 import org.json.JSONException;
 import org.xml.sax.SAXException;
 
@@ -40,13 +42,9 @@ import java.util.ArrayList;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 
-public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener, MediaPlayer.OnCompletionListener {
+public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener, MediaPlayer.OnCompletionListener {
     Intent intent;
-    String query;
-
-    Integer state;
-
-    Integer[] region = null;
+    String mainGraphic;
     private GestureDetectorCompat mDetector;
     private BrailleDisplay brailleServiceObj = null;
     @Override
@@ -57,62 +55,14 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
 
     }
 
-    public void updateState() {
-        state++;
-        switch(state){
-            case 0:
-                // Log.d("QUERY", query);
-                try {
-                    brailleServiceObj.display(DataAndMethods.getBitmaps(DataAndMethods.getfreshDoc(), DataAndMethods.presentLayer, false));
-                } catch (IOException | XPathExpressionException | ParserConfigurationException |
-                         SAXException e) {
-                    throw new RuntimeException(e);
-                }
-                DataAndMethods.speaker("Query received: "+query+" ...Double click on top left corner of region of interest or press confirm to query without selection", TextToSpeech.QUEUE_FLUSH);
-                break;
-            case 1:
-                //Log.d("STATE", "State 1");
-                DataAndMethods.speaker("Double click on bottom right corner of region of interest or press confirm to proceed without selection. Press cancel to return", TextToSpeech.QUEUE_FLUSH);
-                break;
-            case 2:
-                //Log.d("STATE", "State 2");
-                DataAndMethods.speaker("Press confirm to query for selected region. Press cancel to return to region selection", TextToSpeech.QUEUE_FLUSH);
-                break;
-        }
-    }
-
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         super.onKeyDown(keyCode, event);
         switch (keyMapping.getOrDefault(keyCode, "default")) {
             case "OK":
-                switch(state){
-                    case 0:
-                    case 2:
-                        // Make request without region
-                        try {
-                            DataAndMethods.sendFollowUpQuery(query, region);
-                        } catch (JSONException | IOException e) {
-                            throw new RuntimeException(e);
-                        }
-                        finish();
-                        break;
-                    default:
-                        DataAndMethods.pingsPlayer(R.raw.image_error);
-                        break;
-                }
                 return true;
             case "CANCEL":
-                switch(state){
-                    case 1:
-                    case 2:
-                        state = -1;
-                        updateState();
-                        break;
-                    default:
-                        DataAndMethods.pingsPlayer(R.raw.image_error);
-                        break;
-                }
+                finish();
                 return true;
             default:
                 Log.d("KEY EVENT", event.toString());
@@ -215,37 +165,6 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
     @Override
     public boolean onDoubleTap(MotionEvent event) {
         Log.d("GESTURE!", "onDoubleTap: " + event.toString());
-        Integer [] pins=DataAndMethods.pinCheck(event.getX(), event.getY());
-        switch(state){
-            case 0:
-                region = new Integer[]{0, 0, 0, 0};
-                region[0] = pins[0];
-                region[1]=pins[1];
-                updateState();
-                break;
-            case 1:
-                region[2] = pins[0];
-                region[3] = pins[1];
-                // Need to check for valid region here; Also set region to null if it is not...
-                if (DataAndMethods.validateRegion(region)){
-                    try {
-                        showRegion(region);
-                    } catch (XPathExpressionException | ParserConfigurationException |
-                             IOException | SAXException e) {
-                        Log.d("EXCEPTION", String.valueOf(e));
-                        throw new RuntimeException(e);
-                    }
-                    updateState();
-                }else{
-                    //DataAndMethods.speaker("Invalid region!");
-                    region = null;
-                    state = -1;
-                    updateState();
-                }
-                break;
-            default:
-                break;
-        }
         return true;
     }
 
@@ -265,8 +184,18 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
     protected void onResume() {
         Log.d("ACTIVITY", "FollowUpQuery Resumed");
         intent = getIntent();
-        query = intent.getStringExtra("query");
-
+        mainGraphic = intent.getStringExtra("image");
+        try {
+            brailleServiceObj.display(DataAndMethods.getBitmaps(DataAndMethods.getfreshDoc(), 0, true));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (XPathExpressionException e) {
+            throw new RuntimeException(e);
+        } catch (ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        } catch (SAXException e) {
+            throw new RuntimeException(e);
+        }
         mDetector = new GestureDetectorCompat(this,this);
         mDetector.setOnDoubleTapListener(this);
 
@@ -281,14 +210,26 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
             return false;
         };
         brailleServiceObj.registerMotionEventHandler(DataAndMethods.handler);
-
-        state = -1;
-        updateState();
         super.onResume();
     }
     @Override
     protected void onPause() {
         Log.d("ACTIVITY", "FollowUpQuery Paused");
+        DataAndMethods.image = mainGraphic;
+        resetGraphicParams();
+        try {
+            setImageDims();
+        } catch (ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (SAXException e) {
+            throw new RuntimeException(e);
+        } catch (XPathExpressionException e) {
+            throw new RuntimeException(e);
+        }
+        DataAndMethods.tempImage = "";
+        DataAndMethods.followup = false;
         DataAndMethods.presentLayer--;
         brailleServiceObj.unregisterMotionEventHandler(DataAndMethods.handler);
         super.onPause();

--- a/app/src/main/java/ca/mcgill/a11y/image/ShowFollowUp.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/ShowFollowUp.java
@@ -20,6 +20,7 @@ import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
 import static ca.mcgill.a11y.image.DataAndMethods.resetGraphicParams;
 import static ca.mcgill.a11y.image.DataAndMethods.setImageDims;
 import static ca.mcgill.a11y.image.DataAndMethods.showRegion;
+import static ca.mcgill.a11y.image.DataAndMethods.titleRead;
 
 import android.content.Intent;
 import android.media.MediaPlayer;
@@ -62,6 +63,7 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
             case "OK":
                 return true;
             case "CANCEL":
+                titleRead = false;
                 finish();
                 return true;
             default:

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/BasicPhotoMapRenderer.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/BasicPhotoMapRenderer.java
@@ -21,17 +21,20 @@ package ca.mcgill.a11y.image.renderers;
 import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
 
 import androidx.core.view.GestureDetectorCompat;
+import androidx.lifecycle.Observer;
 
 import android.content.Intent;
 import android.media.MediaPlayer;
 import android.os.BrailleDisplay;
 import android.os.Bundle;
+import android.speech.tts.TextToSpeech;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import org.xml.sax.SAXException;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
@@ -60,10 +63,32 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
         super.onKeyDown(keyCode, event);
         switch (keyMapping.getOrDefault(keyCode, "default")) {
             case "OK":
-                DataAndMethods.displayGraphic(DataAndMethods.confirmButton, "Exploration");
+                if (DataAndMethods.followup){
+                    try {
+                        DataAndMethods.onShowFollowUp();
+                    } catch (UnsupportedEncodingException e) {
+                        throw new RuntimeException(e);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    } catch (XPathExpressionException e) {
+                        throw new RuntimeException(e);
+                    } catch (ParserConfigurationException e) {
+                        throw new RuntimeException(e);
+                    } catch (SAXException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                else {
+                    DataAndMethods.displayGraphic(DataAndMethods.confirmButton, "Exploration");
+                }
                 return true;
             case "CANCEL":
+                if (DataAndMethods.followup){
+                    DataAndMethods.followup = false;
+                }
+                else{
                 DataAndMethods.displayGraphic(DataAndMethods.backButton, "Exploration");
+                }
                 return true;
             case "MENU":
                 DataAndMethods.pingsPlayer(R.raw.blip);
@@ -97,10 +122,10 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
                         // Speak out label tags based on finger location and ping when detailed description is available
                         if ((tags.get(1)[pins[1]][pins[0]] != null) && (tags.get(1)[pins[1]][pins[0]].trim().length() > 0)) {
                             //Log.d("CHECKING!", tags.get(1)[pins[1]][pins[0]]);
-                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]], "ping");
+                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH, "ping");
                         } else {
                             //Log.d("CHECKING!", tags.get(0)[pins[1]][pins[0]]);
-                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]]);
+                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
                         }
                     }
                 }
@@ -139,7 +164,7 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
         Integer [] pins= DataAndMethods.pinCheck(event.getX(), event.getY());
         try{
             // Speak out detailed description based on finger location
-            DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]]);
+            DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
         }
         catch(RuntimeException ex){
             Log.d("TTS ERROR", String.valueOf(ex));

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
@@ -28,6 +28,7 @@ import android.content.Intent;
 import android.media.MediaPlayer;
 import android.os.BrailleDisplay;
 import android.os.Bundle;
+import android.speech.tts.TextToSpeech;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.KeyEvent;
@@ -132,10 +133,10 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
                         // Speak out label tags based on finger location and ping when detailed description is available
                         if ((tags.get(1)[pins[1]][pins[0]] != null) && (tags.get(1)[pins[1]][pins[0]].trim().length() > 0)) {
                             //Log.d("CHECKING!", tags.get(1)[pins[1]][pins[0]]);
-                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]], "ping");
+                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH, "ping");
                         } else {
                             //Log.d("CHECKING!", tags.get(0)[pins[1]][pins[0]]);
-                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]]);
+                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
                         }
                     }
                 }
@@ -174,7 +175,7 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
         Integer [] pins= DataAndMethods.pinCheck(event.getX(), event.getY());
         try{
             // Speak out detailed description based on finger location
-            DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]]);
+            DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
         }
         catch(RuntimeException ex){
             Log.d("TTS ERROR", String.valueOf(ex));
@@ -228,7 +229,7 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
     @Override
     protected void onResume() {
         Log.d("ACTIVITY", "Exploration Resumed");
-        DataAndMethods.speaker("Exploration mode");
+        DataAndMethods.speaker("Exploration mode", TextToSpeech.QUEUE_FLUSH);
         startService(new Intent(getApplicationContext(), PollingService.class));
         mDetector = new GestureDetectorCompat(this,this);
         mDetector.setOnDoubleTapListener(this);

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/Guidance.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/Guidance.java
@@ -27,6 +27,7 @@ import android.content.Intent;
 import android.media.MediaPlayer;
 import android.os.BrailleDisplay;
 import android.os.Bundle;
+import android.speech.tts.TextToSpeech;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.KeyEvent;
@@ -129,10 +130,10 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
                         // Speak out label tags based on finger location and ping when detailed description is available
                         if ((tags.get(1)[pins[1]][pins[0]] != null) && (tags.get(1)[pins[1]][pins[0]].trim().length() > 0)) {
                             //Log.d("CHECKING!", tags.get(1)[pins[1]][pins[0]]);
-                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]], "ping");
+                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH, "ping");
                         } else {
                             //Log.d("CHECKING!", tags.get(0)[pins[1]][pins[0]]);
-                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]]);
+                            DataAndMethods.speaker(tags.get(0)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
                         }
                     }
                 }
@@ -171,7 +172,7 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
         Integer [] pins= DataAndMethods.pinCheck(event.getX(), event.getY());
         try{
             // Speak out detailed description based on finger location
-            DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]]);
+            DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
         }
         catch(RuntimeException ex){
             Log.d("TTS ERROR", String.valueOf(ex));
@@ -242,7 +243,7 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
     @Override
     protected void onResume() {
         Log.d("ACTIVITY", "Guidance Resumed");
-        DataAndMethods.speaker("Guidance mode");
+        DataAndMethods.speaker("Guidance mode", TextToSpeech.QUEUE_FLUSH);
         startService(new Intent(getApplicationContext(), PollingService.class));
         mDetector = new GestureDetectorCompat(this,this);
         mDetector.setOnDoubleTapListener(this);

--- a/app/src/main/java/ca/mcgill/a11y/image/request_formats/ResponseFormat.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/request_formats/ResponseFormat.java
@@ -40,5 +40,8 @@ public class ResponseFormat {
         public String graphic;
         @SerializedName("layer")
         public String layer;
+
+        @SerializedName("text")
+        public String text;
     }
 }

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/ClassroomSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/ClassroomSelector.java
@@ -29,6 +29,7 @@ import android.content.Intent;
 import android.media.MediaPlayer;
 import android.os.BrailleDisplay;
 import android.os.Bundle;
+import android.speech.tts.TextToSpeech;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.KeyEvent;
@@ -80,10 +81,10 @@ public class ClassroomSelector extends BaseActivity implements MediaPlayer.OnCom
         public void onFocusChange(View view, boolean b) {
             switch (view.getId()){
                 case R.id.exploration_mode:
-                    speaker("Exploration Mode");
+                    speaker("Exploration Mode", TextToSpeech.QUEUE_FLUSH);
                     break;
                 case R.id.guidance_mode:
-                    speaker("Guidance Mode");
+                    speaker("Guidance Mode", TextToSpeech.QUEUE_FLUSH);
                     break;
             }
         }
@@ -96,11 +97,11 @@ public class ClassroomSelector extends BaseActivity implements MediaPlayer.OnCom
                 Intent myIntent = null;
                 if ((findViewById(R.id.exploration_mode)).hasFocus()){
                     myIntent = new Intent(getApplicationContext(), Exploration.class);
-                    DataAndMethods.speaker("Switching to Exploration mode");
+                    DataAndMethods.speaker("Switching to Exploration mode", TextToSpeech.QUEUE_FLUSH);
                 }
                 else if ((findViewById(R.id.guidance_mode)).hasFocus()){
                     myIntent = new Intent(getApplicationContext(), Guidance.class);
-                    DataAndMethods.speaker("Switching to Guidance mode");
+                    DataAndMethods.speaker("Switching to Guidance mode", TextToSpeech.QUEUE_FLUSH);
                 }
                 //Code snippet 3
                 myIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -147,7 +148,7 @@ public class ClassroomSelector extends BaseActivity implements MediaPlayer.OnCom
     @Override
     protected void onResume() {
         Log.d("ACTIVITY", "Classroom Selector Resumed");
-        DataAndMethods.speaker("Classroom Selector");
+        DataAndMethods.speaker("Classroom Selector", TextToSpeech.QUEUE_FLUSH);
         //startService(new Intent(getApplicationContext(), PollingService.class));
         super.onResume();
     }

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/MapSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/MapSelector.java
@@ -22,6 +22,7 @@ import android.content.Intent;
 import android.media.MediaPlayer;
 import android.os.BrailleDisplay;
 import android.os.Bundle;
+import android.speech.tts.TextToSpeech;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -75,7 +76,7 @@ public class MapSelector extends AppCompatActivity implements MediaPlayer.OnComp
                     Double longitude= Double.parseDouble(((EditText) findViewById(R.id.longitude)).getText().toString());
                     DataAndMethods.getMap(latitude, longitude);
                 } catch (NumberFormatException e){
-                    speaker("Invalid coordinates");
+                    speaker("Invalid coordinates", TextToSpeech.QUEUE_FLUSH);
                 } catch (JSONException e) {
                     throw new RuntimeException(e);
                 }
@@ -105,7 +106,7 @@ public class MapSelector extends AppCompatActivity implements MediaPlayer.OnComp
     @Override
     protected void onResume() {
         Log.d("ACTIVITY", "MapSelector Resumed");
-        DataAndMethods.speaker("Map selector");
+        DataAndMethods.speaker("Map selector", TextToSpeech.QUEUE_FLUSH);
         DataAndMethods.image= null;
         super.onResume();
     }

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/ModeSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/ModeSelector.java
@@ -25,6 +25,7 @@ import android.content.Intent;
 import android.media.MediaPlayer;
 import android.os.BrailleDisplay;
 import android.os.Bundle;
+import android.speech.tts.TextToSpeech;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -69,13 +70,13 @@ public class ModeSelector extends BaseActivity implements MediaPlayer.OnCompleti
         public void onFocusChange(View view, boolean b) {
             switch (view.getId()){
                 case R.id.classroom_mode:
-                    speaker("Classroom Mode");
+                    speaker("Classroom Mode", TextToSpeech.QUEUE_FLUSH);
                     break;
                 case R.id.photo_mode:
-                    speaker("Photo Mode");
+                    speaker("Photo Mode", TextToSpeech.QUEUE_FLUSH);
                     break;
                 case R.id.map_mode:
-                    speaker("Map Mode");
+                    speaker("Map Mode", TextToSpeech.QUEUE_FLUSH);
                     break;
                 // Code snippet 2
             }
@@ -89,16 +90,16 @@ public class ModeSelector extends BaseActivity implements MediaPlayer.OnCompleti
                 Intent myIntent = null;
                 if ((findViewById(R.id.classroom_mode)).hasFocus()){
                     myIntent = new Intent(getApplicationContext(), ClassroomSelector.class);
-                    DataAndMethods.speaker("Switching to Classroom mode");
+                    DataAndMethods.speaker("Switching to Classroom mode", TextToSpeech.QUEUE_FLUSH);
                 }
                 else if ((findViewById(R.id.photo_mode)).hasFocus()){
                     myIntent = new Intent(getApplicationContext(), PhotoSelector.class);
-                    DataAndMethods.speaker("Switching to Photo mode");
+                    DataAndMethods.speaker("Switching to Photo mode", TextToSpeech.QUEUE_FLUSH);
 
                 }
                 else if ((findViewById(R.id.map_mode)).hasFocus()){
                     myIntent = new Intent(getApplicationContext(), MapSelector.class);
-                    DataAndMethods.speaker("Switching to Map mode");
+                    DataAndMethods.speaker("Switching to Map mode", TextToSpeech.QUEUE_FLUSH);
                 }
                 //Code snippet 3
                 myIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -124,7 +125,7 @@ public class ModeSelector extends BaseActivity implements MediaPlayer.OnCompleti
     @Override
     protected void onResume() {
         Log.d("ACTIVITY", "ModeSelector Resumed");
-        DataAndMethods.speaker("Mode selector");
+        DataAndMethods.speaker("Mode selector", TextToSpeech.QUEUE_FLUSH);
         DataAndMethods.image = null;
         update.setValue(false);
         super.onResume();

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/PhotoSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/PhotoSelector.java
@@ -25,6 +25,7 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.media.MediaPlayer;
 import android.os.Bundle;
+import android.speech.tts.TextToSpeech;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -62,7 +63,7 @@ public class PhotoSelector extends BaseActivity implements MediaPlayer.OnComplet
             case "UP":
                 Log.d("KEY EVENT", event.toString());
                 try {
-                    DataAndMethods.speaker(DataAndMethods.getFile(++fileSelected));
+                    DataAndMethods.speaker(DataAndMethods.getFile(++fileSelected), TextToSpeech.QUEUE_FLUSH);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 } catch (JSONException e) {
@@ -72,7 +73,7 @@ public class PhotoSelector extends BaseActivity implements MediaPlayer.OnComplet
             case "DOWN":
                 Log.d("KEY EVENT", event.toString());
                 try {
-                    DataAndMethods.speaker(DataAndMethods.getFile(--fileSelected));
+                    DataAndMethods.speaker(DataAndMethods.getFile(--fileSelected), TextToSpeech.QUEUE_FLUSH);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 } catch (JSONException e) {
@@ -109,7 +110,7 @@ public class PhotoSelector extends BaseActivity implements MediaPlayer.OnComplet
     @Override
     protected void onResume() {
         Log.d("ACTIVITY", "PhotoSelector Resumed");
-        DataAndMethods.speaker("Photo selector");
+        DataAndMethods.speaker("Photo selector", TextToSpeech.QUEUE_FLUSH);
         try {
             // might want to read file name here
             DataAndMethods.getFile(++DataAndMethods.fileSelected);


### PR DESCRIPTION
Merge a working version of follow-up query demo which works with a single returned response for follow-up query for both text and tactile response. 