### PR TITLE
Decryption logic for graphics fetched from Monarch backend component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+
+#password file
+app/src/main/res/values/secret.xml

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ You might will also need to do some (or all) of the following (especially for a 
 - Grant permission to the application to read from storage. Do this by running the adb command `adb shell pm grant ca.mcgill.a11y.image android.permission.READ_EXTERNAL_STORAGE`
 - Create a directory `/sdcard/IMAGE/client/` on the Monarch sdcard for the application to read from. The application reads files from this directory. So you will need to copy over your 'graphic' files to this location.
 - You may be asked for microphone permissions on the Monarch. For this, it is best to download [ScreenCopy](https://github.com/Genymobile/scrcpy) to navigate through the permissions setup.
+- The graphics fetched in classroom mode (i.e. graphics published either from [Tactile Authoring Tool (TAT)](https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring/) or IMAGE-Extension(https://github.com/Shared-Reality-Lab/IMAGE-browser)) are accessed by decrypting using the same password used by the publisher. This password needs to be configured by creating a new file app/src/main/res/values/secret.xml and entering
+```
+<resources>
+    <string name="password">[my-password-goes-here]</string>
+</resources>
+```
 
 
 ## Details...

--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -221,7 +221,7 @@ public class DataAndMethods {
                 public void onInit(int status) {
 
                     if (status != TextToSpeech.SUCCESS) {
-                        Log.e("error", "Initialization Failed!" + -status);
+                        Log.e("error", "Initialization Failed!" + status);
                     } else {
                         tts.setLanguage(Locale.getDefault());
                         tts.setOnUtteranceProgressListener(new UtteranceProgressListener() {

--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -221,7 +221,7 @@ public class DataAndMethods {
                 public void onInit(int status) {
 
                     if (status != TextToSpeech.SUCCESS) {
-                        Log.e("error", "Initialization Failed!" + status);
+                        Log.e("error", "Initialization Failed!" + -status);
                     } else {
                         tts.setLanguage(Locale.getDefault());
                         tts.setOnUtteranceProgressListener(new UtteranceProgressListener() {
@@ -850,13 +850,19 @@ public class DataAndMethods {
                         ResponseFormat resource = response.body();
                         ResponseFormat.Rendering[] renderings = resource.renderings;
                         if (history.temp_request == null || !history.temp_request.has("followup")){
-                            image =(renderings[0].data.graphic).replaceFirst("data:.+,", "");
-                            //Log.d("RESPONSE", image);
-                            image = decrypt(image, context.getString(R.string.password));//.replaceFirst("data:.+,", "");
-                            //byte[] data = image.getBytes("UTF-8");
-                            //data = Base64.decode(data, Base64.DEFAULT);
-                            //image = new String(data, "UTF-8");
-                            //Log.d("IMAGE", image);
+                            image =(renderings[0].data.graphic);
+                            // Check if data is encrypted or contains data:image...
+                            // and process accordingly
+                            if (image.contains("data:")){
+                                image = image.replaceFirst("data:.+,", "");
+                                byte[] data = image.getBytes("UTF-8");
+                                data = Base64.decode(data, Base64.DEFAULT);
+                                image = new String(data, "UTF-8");
+                                //Log.d("IMAGE", image);
+                            }
+                            else{
+                                image = decrypt(image, context.getString(R.string.password));
+                            }
                             // gets viewBox dims for current image
                             resetGraphicParams();
                             setImageDims();

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/ClassroomSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/ClassroomSelector.java
@@ -59,7 +59,7 @@ import ca.mcgill.a11y.image.renderers.Exploration;
 import ca.mcgill.a11y.image.renderers.Guidance;
 
 public class ClassroomSelector extends BaseActivity implements MediaPlayer.OnCompletionListener {
-    public static String channelSubscribed = "263773"; // make this the place the request takes it from
+    public static String channelSubscribed = "514446"; // make this the place the request takes it from
 
     @SuppressLint("WrongConstant")
     @Override


### PR DESCRIPTION
The graphics fetched in classroom mode (i.e. graphics published either from [Tactile Authoring Tool (TAT)](https://github.com/Shared-Reality-Lab/IMAGE-TactileAuthoring/) or IMAGE-Extension(https://github.com/Shared-Reality-Lab/IMAGE-browser)) need to be accessed by decrypting using the same password used by the publisher. 
This PR includes:
1. Decryption logic
2. Password configuration for decryption and documentation on how to do the same

This covers item **6.** Shared-Reality-Lab/IMAGE-browser#391
