### PR TITLE
Classroom followup implementation

### DIFF
--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -112,7 +112,9 @@ import ca.mcgill.a11y.image.request_formats.PhotoRequestFormat;
 import ca.mcgill.a11y.image.request_formats.ResponseFormat;
 import okhttp3.Cache;
 import okhttp3.OkHttpClient;
+import okhttp3.RequestBody;
 import okhttp3.logging.HttpLoggingInterceptor;
+import okio.Buffer;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -157,7 +159,8 @@ public class DataAndMethods {
     public static BrailleDisplay.MotionEventHandler handler;
     // keep track of current request to server
     private static Call<ResponseFormat> ongoingCall;
-    public static MutableLiveData<Boolean> followingUp = new MutableLiveData<>(false);
+    private static Call<ResponseFormat> ongoingFollowUp;
+    //public static MutableLiveData<Boolean> followingUp = new MutableLiveData<>(false);
     // TTS engine instance
     static TextToSpeech tts = null;
     // application context
@@ -232,7 +235,9 @@ public class DataAndMethods {
                         tts.setOnUtteranceProgressListener(new UtteranceProgressListener() {
                             @Override
                             public void onStart(String s) {
-
+                                if (s.equals("forceSpeak")) {
+                                    forceSpeak = null;
+                                }
                             }
 
                             @Override
@@ -241,12 +246,10 @@ public class DataAndMethods {
                                 // plays ping when TTS readout is completed based on utteranceId
                                 if (s.equals("ping")) {
                                     pingsPlayer(R.raw.blip);
-                                } else if (s.equals("forceSpeak")) {
-                                    forceSpeak = null;
                                 }
                                 if (forceSpeak!= null){
-                                    speaker(forceSpeak, TextToSpeech.QUEUE_FLUSH);
-                                    forceSpeak = null;
+                                    speaker(forceSpeak, TextToSpeech.QUEUE_FLUSH, "forceSpeak");
+                                    //forceSpeak = null;
                                 }
                             }
 
@@ -714,8 +717,8 @@ public class DataAndMethods {
 
         MakeRequest makereq= retrofit.create(MakeRequest.class);
         Call<ResponseFormat> call= makereq.makePhotoRequest(req);
-        history.updateHistory(req);
-        makeServerCall(call);
+        //history.updateHistory(req);
+        makeServerCall(call, false);
         // The regex expression in replaceFirst removes everything following the '.' i.e. .jpg, .png etc.
         return files[fileSelected].getName().replaceFirst("\\.[^.]*$", "");
     }
@@ -771,8 +774,8 @@ public class DataAndMethods {
                 "https://image.a11y.mcgill.ca/");
         MakeRequest makereq= retrofit.create(MakeRequest.class);
         Call<ResponseFormat> call= makereq.makeMapRequest(req);
-        history.updateHistory(req);
-        makeServerCall(call);
+        //history.updateHistory(req);
+        makeServerCall(call, false);
     }
 
     // fetches updates from server if they exist
@@ -781,7 +784,7 @@ public class DataAndMethods {
 
         MakeRequest makereq= retrofit.create(MakeRequest.class);
         Call<ResponseFormat> call= makereq.checkForUpdates(context.getString(R.string.server_url)+"display/"+channelSubscribed);
-        makeServerCall(call);
+        makeServerCall(call, false);
     }
 
     // initializes dims, zoomBox and origDims for new graphic
@@ -848,10 +851,17 @@ public class DataAndMethods {
     }
 
     // makes async call to serevr
-    public static void makeServerCall(Call<ResponseFormat> call){
+    public static void makeServerCall(Call<ResponseFormat> call, Boolean isFollowup){
         // Cancelling any ongoing requests that haven't been completed
-        if (ongoingCall!=null){
-            ongoingCall.cancel();
+        if (isFollowup){
+            if (ongoingFollowUp!=null){
+                ongoingFollowUp.cancel();
+            }
+        }
+        else{
+            if (ongoingCall!=null){
+                ongoingCall.cancel();
+            }
         }
         update.setValue(false);
         call.enqueue(new Callback<ResponseFormat>() {
@@ -861,7 +871,14 @@ public class DataAndMethods {
                     if (response.raw().networkResponse().code() != HttpURLConnection.HTTP_NOT_MODIFIED || image == null) {
                         ResponseFormat resource = response.body();
                         ResponseFormat.Rendering[] renderings = resource.renderings;
-                        if (history.temp_request == null || !history.temp_request.has("followup")){
+                        //if (history.temp_request == null || !history.temp_request.has("followup")){
+                        //Log.d("REQ_BODY", String.valueOf(call.request().body()));
+                        // only log history if request body exists; this is false for classroom mode
+                        if (call.request().body() != null){
+                            JSONObject req = new JSONObject(requestBodyToString(call.request().body()));
+                            history.updateHistory(req);
+                        }
+                        if (!isFollowup){
                             image =(renderings[0].data.graphic);
                             // Check if data is encrypted or contains data:image...
                             // and process accordingly
@@ -875,13 +892,17 @@ public class DataAndMethods {
                             else{
                                 // Log.d("graphicBlob", resource.graphicBlob);
                                 String srcGraphic = decrypt(resource.graphicBlob, "abc");
+                                // log history for classroom mode
                                 byte[] decodedBytes = Base64.decode(srcGraphic.replaceFirst("data:.+,", ""), Base64.DEFAULT);
                                 Bitmap bitmap = BitmapFactory.decodeByteArray(decodedBytes, 0, decodedBytes.length);
                                 Integer[] dims= new Integer[] {bitmap.getWidth(), bitmap.getHeight()};
-                                PhotoRequestFormat req= new PhotoRequestFormat();
-                                req.setValues(srcGraphic, dims);
+                                PhotoRequestFormat rq= new PhotoRequestFormat();
+                                rq.setValues(srcGraphic, dims);
                                 // Log.d("HISTORY", String.valueOf(history.temp_request));
-                                history.updateHistory(req);
+                                Gson gson = new Gson();
+                                String json = gson.toJson(rq);
+                                JSONObject request = new JSONObject(json);
+                                history.updateHistory(request);
                                 image = decrypt(image, context.getString(R.string.password));
                             }
                             // gets viewBox dims for current image
@@ -905,7 +926,7 @@ public class DataAndMethods {
                                 // Log.d("FOLLOW UP", furesponse);
                                 forceSpeak = furesponse;
                                 speaker(furesponse, TextToSpeech.QUEUE_ADD, "forceSpeak");
-                                followingUp.setValue(false);
+                                //followingUp.setValue(false);
                             }
                             else if(renderings[0].type_id.contains("TactileSVG")){
                                 furesponse = renderings[0].data.graphic;
@@ -920,7 +941,7 @@ public class DataAndMethods {
                             //}
                             history.setResponse(furesponse);
                         }
-                        history.setHistory(true);
+                        //history.setHistory(true);
                         pingsPlayer(R.raw.image_results_arrived);
                         update.setValue(true);
                     }
@@ -931,14 +952,14 @@ public class DataAndMethods {
                 // This occurs when there is no rendering returned
                 catch (IOException | ParserConfigurationException | SAXException |
                        XPathExpressionException e) {
-                    history.setHistory(false);
+                    //history.setHistory(false);
                     throw new RuntimeException(e);
                 } catch (ArrayIndexOutOfBoundsException | NullPointerException e){
                     pingsPlayer(R.raw.image_error);
-                    if (followingUp.getValue()){
+                    /*if (followingUp.getValue()){
                         followingUp.setValue(false);
-                    }
-                    history.setHistory(false);
+                    }*/
+                    //history.setHistory(false);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -959,7 +980,10 @@ public class DataAndMethods {
             }
         });
         // Saving the in-progress call to allow interruption if needed
-        ongoingCall=call;
+        if (isFollowup)
+            ongoingFollowUp = call;
+        else
+            ongoingCall = call;
     }
 
     // resets zoom and dimension related variables for new graphics
@@ -1392,8 +1416,8 @@ public class DataAndMethods {
                 String[][] previous = setPrevious();
                 req.setPrevious(previous);
             }
-            history.updateHistory(req);
-            followingUp.setValue(true);
+            //history.updateHistory(req);
+            //followingUp.setValue(true);
             call= makereq.makePhotoRequest(req);
         }
         else if (history.type.equals("Map")){
@@ -1409,7 +1433,7 @@ public class DataAndMethods {
                 String[][] previous = setPrevious();
                 req.setPrevious(previous);
             }
-            history.updateHistory(req);
+            //history.updateHistory(req);
             call = makereq.makeMapRequest(req);
         }
 
@@ -1419,7 +1443,7 @@ public class DataAndMethods {
 
 
         // need to make a separate function so that 'image' is not replaced
-        makeServerCall(call);
+        makeServerCall(call, true);
         pingsPlayer(R.raw.image_request_sent);
 
     }
@@ -1444,7 +1468,130 @@ public class DataAndMethods {
         return previous.toArray(new String[][]{});
     }
 
+    /*
+    public static void makeFollowUpServerCall(Call<ResponseFormat> call) throws IOException, JSONException {
+        // Cancelling any ongoing requests that haven't been completed
+        if (ongoingFollowUp!=null){
+            ongoingFollowUp.cancel();
+        }
+        update.setValue(false);
+        call.enqueue(new Callback<ResponseFormat>() {
+            @Override
+            public void onResponse(Call<ResponseFormat> call, Response<ResponseFormat> response) {
+                try {
+                    if (response.raw().networkResponse().code() != HttpURLConnection.HTTP_NOT_MODIFIED || image == null) {
+                        ResponseFormat resource = response.body();
+                        ResponseFormat.Rendering[] renderings = resource.renderings;
+                        // this is where followup response is handled
+                        //Log.d("FOLLOW UP", "Found followup field");
+                        String furesponse = "";
+                        //for (int i=0; i< renderings.length; i++){
+                        if (renderings[0].type_id.contains("Text")){
+                            furesponse = renderings[0].data.text;
+                            // Log.d("FOLLOW UP", furesponse);
+                            forceSpeak = furesponse;
+                            speaker(furesponse, TextToSpeech.QUEUE_ADD, "forceSpeak");
+                            //followingUp.setValue(false);
+                        }
+                        else if(renderings[0].type_id.contains("TactileSVG")){
+                            furesponse = renderings[0].data.graphic;
+                            tempImage = furesponse;
+                            speaker("Tactile response received. Press confirm to view it. Press cancel to ignore", TextToSpeech.QUEUE_ADD);
+                            followup = true;
+                        }
+                        else{
+                            furesponse = "Response received in type that is not handled yet";
+                        }
+                        history.setResponse(furesponse);
+                        history.setHistory(true);
+                        update.setValue(true);
+                        pingsPlayer(R.raw.image_results_arrived);
+                    }
+                    else{
+                        Log.d("CACHE", "Fetching from cache!");
+                    }
+                }
+                // This occurs when there is no rendering returned
+                catch (ArrayIndexOutOfBoundsException | NullPointerException e){
+                    pingsPlayer(R.raw.image_error);
+                    history.setHistory(false);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
 
+            //onFailure is called both when a request is cancelled (i.e. interrupted with another request)
+            // AND when it fails to give a valid response
+            @Override
+            public void onFailure(Call<ResponseFormat> call, Throwable t) {
+                // Ensure that a request was cancelled before playing error ping
+                // This text is not read out when a request is cancelled as there is expected to be
+                // an ongoing request and can be confused as a result of that request.
+                // Causes interrupted requests to die silently!
+                Log.d("RESPONSE", "FAILED!");
+                if (!call.isCanceled()){
+                    pingsPlayer(R.raw.image_error);
+                }
+            }
+        });
+        // Saving the in-progress call to allow interruption if needed
+        ongoingFollowUp=call;
+        Log.d("CALL", requestBodyToString(call.request().body()));
+        JSONObject mainObject = new JSONObject(requestBodyToString(call.request().body()));
+    }*/
+
+
+    public static String requestBodyToString(RequestBody requestBody) throws IOException {
+        Buffer buffer = new Buffer();
+        requestBody.writeTo(buffer);
+        return buffer.readUtf8();
+    }
+    public static String decrypt(String encryptedBase64, String password) throws Exception {
+        // Convert the Base64-encoded encrypted data and IV to byte arrays
+        byte[] encrypted = Base64.decode(encryptedBase64, Base64.NO_WRAP);
+
+        byte[] salt = Arrays.copyOfRange(encrypted, 0, 16);
+        byte[] iv = Arrays.copyOfRange(encrypted, 16, 32);
+        byte[] encryptedData = Arrays.copyOfRange(encrypted, 32, encrypted.length);
+        // byte[] iv = Base64.decode(ivBase64, Base64.NO_WRAP);
+        //Log.d("DECODED", convertToUnsignedBytes(iv));
+        //Log.d("DECODED DATA", convertToUnsignedBytes(encryptedData));
+
+        // Derive the AES key from the password using PBKDF2
+        //byte[] salt = Base64.decode(saltBase64, Base64.NO_WRAP);  // Use the same salt used in encryption
+        SecretKey key = deriveKey(password, salt);
+
+        // Create the AES key from the password
+        SecretKeySpec secretKey = new SecretKeySpec(key.getEncoded(), "AES");
+
+        // Create Cipher instance for AES in CBC mode
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
+
+        // Setup the IvParameterSpec with the IV for decryption
+        IvParameterSpec ivSpec = new IvParameterSpec(iv);
+
+        // Decrypt the data
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, ivSpec);
+        byte[] decryptedData = cipher.doFinal(encryptedData);
+
+        // Convert the decrypted byte array back to a string
+        return new String(decryptedData, StandardCharsets.UTF_8);
+    }
+    public static String convertToUnsignedBytes(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append((b & 0xFF)).append(", ");
+        }
+        return sb.toString();
+    }
+
+    // Derive the AES key from the password using PBKDF2
+    private static SecretKey deriveKey(String password, byte[] salt) throws Exception {
+        PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, 100000, 256);
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+        byte[] key = factory.generateSecret(spec).getEncoded();
+        return new javax.crypto.spec.SecretKeySpec(key, "AES");
+    }
 
     // this is used to replicate what the outcome of a server call is for the demo example
     public static void makePseudoServerCall(){
@@ -1455,52 +1602,4 @@ public class DataAndMethods {
                         "\n<ellipse fill=\"none\" stroke=\"#000000\" stroke-width=\"0.885\" id=\"path358\" " +
                         "cx=\"48\" cy=\"20\" rx=\"15\" ry=\"15\" /> </g> \n</svg>";
     }
-
-    public static String decrypt(String encryptedBase64, String password) throws Exception {
-            // Convert the Base64-encoded encrypted data and IV to byte arrays
-            byte[] encrypted = Base64.decode(encryptedBase64, Base64.NO_WRAP);
-
-            byte[] salt = Arrays.copyOfRange(encrypted, 0, 16);
-            byte[] iv = Arrays.copyOfRange(encrypted, 16, 32);
-            byte[] encryptedData = Arrays.copyOfRange(encrypted, 32, encrypted.length);
-            // byte[] iv = Base64.decode(ivBase64, Base64.NO_WRAP);
-            //Log.d("DECODED", convertToUnsignedBytes(iv));
-            //Log.d("DECODED DATA", convertToUnsignedBytes(encryptedData));
-
-            // Derive the AES key from the password using PBKDF2
-            //byte[] salt = Base64.decode(saltBase64, Base64.NO_WRAP);  // Use the same salt used in encryption
-            SecretKey key = deriveKey(password, salt);
-
-            // Create the AES key from the password
-            SecretKeySpec secretKey = new SecretKeySpec(key.getEncoded(), "AES");
-
-            // Create Cipher instance for AES in CBC mode
-            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
-
-            // Setup the IvParameterSpec with the IV for decryption
-            IvParameterSpec ivSpec = new IvParameterSpec(iv);
-
-            // Decrypt the data
-            cipher.init(Cipher.DECRYPT_MODE, secretKey, ivSpec);
-            byte[] decryptedData = cipher.doFinal(encryptedData);
-
-            // Convert the decrypted byte array back to a string
-            return new String(decryptedData, StandardCharsets.UTF_8);
-        }
-        public static String convertToUnsignedBytes(byte[] bytes) {
-            StringBuilder sb = new StringBuilder();
-            for (byte b : bytes) {
-                sb.append((b & 0xFF)).append(", ");
-            }
-            return sb.toString();
-        }
-
-        // Derive the AES key from the password using PBKDF2
-        private static SecretKey deriveKey(String password, byte[] salt) throws Exception {
-            PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, 100000, 256);
-            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-            byte[] key = factory.generateSecret(spec).getEncoded();
-            return new javax.crypto.spec.SecretKeySpec(key, "AES");
-        }
-
 }

--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -28,6 +28,7 @@ import static android.view.KeyEvent.KEYCODE_ZOOM_OUT;
 
 import static ca.mcgill.a11y.image.selectors.ClassroomSelector.channelSubscribed;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -178,6 +179,7 @@ public class DataAndMethods {
     public static Boolean titleRead = true;
     public static String tempImage = "";
     public static String forceSpeak = null;
+    public static Boolean silentStart = false;
     // mapping of keyCodes
     public static Map<Integer, String> keyMapping = new HashMap<Integer, String>() {{
         put(421, "UP");
@@ -345,11 +347,12 @@ public class DataAndMethods {
             myIntent.putExtra("query", results);
             myIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             DataAndMethods.context.startActivity(myIntent);
+            //((Activity)DataAndMethods.context).startActivityForResult(myIntent, 1);
         }else
             Log.d("onVoiceRecognitionResults", "NOT HANDLED YET!");
     }
     //check mode and display appropriate layer
-    public static void displayGraphic(int keyCode, String mode){
+    public static void displayGraphic(int keyCode, String mode, Boolean silentStart){
         try{if (mode=="Exploration"){
 
                 DataAndMethods.ttsEnabled=true;
@@ -359,7 +362,7 @@ public class DataAndMethods {
                 else{
                     -- DataAndMethods.presentLayer;
                 }
-                brailleServiceObj.display(DataAndMethods.getBitmaps(DataAndMethods.getfreshDoc(), DataAndMethods.presentLayer, true));
+                brailleServiceObj.display(DataAndMethods.getBitmaps(DataAndMethods.getfreshDoc(), DataAndMethods.presentLayer, !silentStart));
 
 
 
@@ -371,7 +374,7 @@ public class DataAndMethods {
             else{
                 -- DataAndMethods.presentTarget;
             }
-            brailleServiceObj.display(DataAndMethods.getGuidanceBitmaps(DataAndMethods.getfreshDoc(), true));
+            brailleServiceObj.display(DataAndMethods.getGuidanceBitmaps(DataAndMethods.getfreshDoc(), !silentStart));
         }}
         catch(IOException | SAXException | ParserConfigurationException | XPathExpressionException e) {
             throw new RuntimeException(e);
@@ -1417,6 +1420,7 @@ public class DataAndMethods {
 
         // need to make a separate function so that 'image' is not replaced
         makeServerCall(call);
+        pingsPlayer(R.raw.image_request_sent);
 
     }
     

--- a/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
@@ -122,6 +122,10 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                         break;
                 }
                 return true;
+            case "BACK":
+                DataAndMethods.update.setValue(true);
+                finish();
+                return true;
             default:
                 Log.d("KEY EVENT", event.toString());
                 return false;

--- a/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
@@ -18,10 +18,13 @@ package ca.mcgill.a11y.image;
 
 import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
 import static ca.mcgill.a11y.image.DataAndMethods.showRegion;
+import static ca.mcgill.a11y.image.DataAndMethods.silentStart;
+import static ca.mcgill.a11y.image.DataAndMethods.speaker;
 import static ca.mcgill.a11y.image.DataAndMethods.titleRead;
 
 import androidx.core.view.GestureDetectorCompat;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.media.MediaPlayer;
 import android.os.BrailleDisplay;
@@ -97,6 +100,9 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                             throw new RuntimeException(e);
                         }
                         titleRead = false;
+                        silentStart = true;
+                        // cut the speech
+                        speaker("", TextToSpeech.QUEUE_FLUSH);
                         finish();
                         break;
                     default:

--- a/app/src/main/java/ca/mcgill/a11y/image/History.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/History.java
@@ -8,6 +8,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.Console;
+import java.util.Iterator;
 
 // keeping track of requests history
 public class History{
@@ -18,7 +19,7 @@ public class History{
 
     String response;
 
-    public void updateHistory(Object req) throws JSONException {
+    /*public void updateHistory(Object req) throws JSONException {
         Gson gson = new Gson();
         String json = gson.toJson(req);
         JSONObject jsonObject = new JSONObject(json);
@@ -37,6 +38,22 @@ public class History{
         this.temp_type = null;
         this.temp_request = null;
         // Log.d("HISTORY", history() );
+    }*/
+    public void updateHistory(JSONObject jsonObject) throws JSONException {
+        if (jsonObject.has("graphic")){
+            this.type = "Photo";
+        } else if (jsonObject.has("coordinates")) {
+            this.type = "Map";
+        }
+        this.request = jsonObject;
+
+        /*Iterator<String> iterator = jsonObject.keys(); // Your Iterator<String> object
+        StringBuilder sb = new StringBuilder();
+
+        while (iterator.hasNext()) {
+            sb.append(iterator.next()).append(", "); // Append each element
+        }
+        Log.d("KEYS", sb.toString());*/
     }
 
     // public String history(){

--- a/app/src/main/java/ca/mcgill/a11y/image/History.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/History.java
@@ -14,31 +14,8 @@ import java.util.Iterator;
 public class History{
     String type;
     JSONObject request;
-    String temp_type;
-    JSONObject temp_request;
-
     String response;
 
-    /*public void updateHistory(Object req) throws JSONException {
-        Gson gson = new Gson();
-        String json = gson.toJson(req);
-        JSONObject jsonObject = new JSONObject(json);
-        if (jsonObject.has("graphic")){
-            this.temp_type = "Photo";
-        } else if (jsonObject.has("coordinates")) {
-            this.temp_type = "Map";
-        }
-        this.temp_request = jsonObject;
-    }
-    public void setHistory(Boolean set){
-        if (set){
-            this.type = this.temp_type;
-            this.request = this.temp_request;
-        }
-        this.temp_type = null;
-        this.temp_request = null;
-        // Log.d("HISTORY", history() );
-    }*/
     public void updateHistory(JSONObject jsonObject) throws JSONException {
         if (jsonObject.has("graphic")){
             this.type = "Photo";
@@ -46,23 +23,10 @@ public class History{
             this.type = "Map";
         }
         this.request = jsonObject;
-
-        /*Iterator<String> iterator = jsonObject.keys(); // Your Iterator<String> object
-        StringBuilder sb = new StringBuilder();
-
-        while (iterator.hasNext()) {
-            sb.append(iterator.next()).append(", "); // Append each element
-        }
-        Log.d("KEYS", sb.toString());*/
     }
-
-    // public String history(){
-    //    return this.type + ", " + this.request;
-    // }
 
     public void setResponse(String response){
         this.response = response;
     }
-
 
 }

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/BasicPhotoMapRenderer.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/BasicPhotoMapRenderer.java
@@ -19,10 +19,12 @@ package ca.mcgill.a11y.image.renderers;
 
 
 import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
+import static ca.mcgill.a11y.image.DataAndMethods.silentStart;
 
 import androidx.core.view.GestureDetectorCompat;
 import androidx.lifecycle.Observer;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.media.MediaPlayer;
 import android.os.BrailleDisplay;
@@ -79,7 +81,7 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
                     }
                 }
                 else {
-                    DataAndMethods.displayGraphic(DataAndMethods.confirmButton, "Exploration");
+                    DataAndMethods.displayGraphic(DataAndMethods.confirmButton, "Exploration", false);
                 }
                 return true;
             case "CANCEL":
@@ -87,7 +89,7 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
                     DataAndMethods.followup = false;
                 }
                 else{
-                DataAndMethods.displayGraphic(DataAndMethods.backButton, "Exploration");
+                DataAndMethods.displayGraphic(DataAndMethods.backButton, "Exploration", false);
                 }
                 return true;
             case "MENU":
@@ -209,13 +211,12 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
         return true;
     }
 
-
-
     @Override
     protected void onResume() {
         Log.d("ACTIVITY", "Exploration Resumed");
 
-        DataAndMethods.displayGraphic(DataAndMethods.confirmButton, "Exploration");
+        DataAndMethods.displayGraphic(DataAndMethods.confirmButton, "Exploration", silentStart);
+        silentStart = false;
 
         mDetector = new GestureDetectorCompat(this,this);
         mDetector.setOnDoubleTapListener(this);

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
@@ -22,9 +22,11 @@ import static ca.mcgill.a11y.image.DataAndMethods.confirmButton;
 import static ca.mcgill.a11y.image.DataAndMethods.displayGraphic;
 import static ca.mcgill.a11y.image.DataAndMethods.followingUp;
 import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
+import static ca.mcgill.a11y.image.DataAndMethods.silentStart;
 import static ca.mcgill.a11y.image.DataAndMethods.update;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Intent;
 import android.media.MediaPlayer;
 import android.os.BrailleDisplay;
@@ -34,6 +36,7 @@ import android.util.Log;
 import android.view.GestureDetector;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
+import android.widget.Toast;
 
 import androidx.core.view.GestureDetectorCompat;
 import androidx.lifecycle.MutableLiveData;
@@ -75,7 +78,9 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
             @Override
             public void onChanged(Boolean changedVal) {
                 if (changedVal && DataAndMethods.image != null){
-                    displayGraphic(confirmButton, "Exploration");
+                    displayGraphic(confirmButton, "Exploration", silentStart);
+                    if (silentStart)
+                        silentStart = false;
                 }
             }
 
@@ -114,12 +119,12 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
 
                 case "OK":
                     if (DataAndMethods.image!= null)
-                        DataAndMethods.displayGraphic(confirmButton, "Exploration");
+                        DataAndMethods.displayGraphic(confirmButton, "Exploration", false);
                     return false;
 
                 case "CANCEL":
                     if (DataAndMethods.image!= null)
-                        DataAndMethods.displayGraphic(backButton, "Exploration");
+                        DataAndMethods.displayGraphic(backButton, "Exploration", false);
                     return false;
                 case "MENU":
                     DataAndMethods.pingsPlayer(R.raw.blip);
@@ -240,11 +245,12 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
         mediaPlayer.release();
     }
 
-
     @Override
     protected void onResume() {
         Log.d("ACTIVITY", "Exploration Resumed");
-        DataAndMethods.speaker("Exploration mode", TextToSpeech.QUEUE_FLUSH);
+        if (!silentStart)
+            DataAndMethods.speaker("Exploration mode", TextToSpeech.QUEUE_FLUSH);
+
         if (!followingUp.getValue()) {
             startService(new Intent(getApplicationContext(), PollingService.class));
         }

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
@@ -20,6 +20,7 @@ package ca.mcgill.a11y.image.renderers;
 import static ca.mcgill.a11y.image.DataAndMethods.backButton;
 import static ca.mcgill.a11y.image.DataAndMethods.confirmButton;
 import static ca.mcgill.a11y.image.DataAndMethods.displayGraphic;
+import static ca.mcgill.a11y.image.DataAndMethods.followingUp;
 import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
 import static ca.mcgill.a11y.image.DataAndMethods.update;
 
@@ -51,6 +52,7 @@ import androidx.lifecycle.MutableLiveData;
 import ca.mcgill.a11y.image.BaseActivity;
 import ca.mcgill.a11y.image.DataAndMethods;
 import ca.mcgill.a11y.image.PollingService;
+import ca.mcgill.a11y.image.R;
 
 public class Exploration extends BaseActivity implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener, MediaPlayer.OnCompletionListener {
     private BrailleDisplay brailleServiceObj = null;
@@ -77,6 +79,15 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
                 }
             }
 
+        });
+
+        followingUp.observe(this,new Observer<Boolean>() {
+            @Override
+            public void onChanged(Boolean changedVal) {
+                if (!changedVal){
+                    startService(new Intent(getApplicationContext(), PollingService.class));
+                }
+            }
         });
     }
 
@@ -110,6 +121,10 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
                     if (DataAndMethods.image!= null)
                         DataAndMethods.displayGraphic(backButton, "Exploration");
                     return false;
+                case "MENU":
+                    DataAndMethods.pingsPlayer(R.raw.blip);
+                    DataAndMethods.speechRecognizer.startListening(DataAndMethods.speechRecognizerIntent);
+                    return true;
                 default:
                     Log.d("KEY EVENT", event.toString());
                     return false;
@@ -230,7 +245,9 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
     protected void onResume() {
         Log.d("ACTIVITY", "Exploration Resumed");
         DataAndMethods.speaker("Exploration mode", TextToSpeech.QUEUE_FLUSH);
-        startService(new Intent(getApplicationContext(), PollingService.class));
+        if (!followingUp.getValue()) {
+            startService(new Intent(getApplicationContext(), PollingService.class));
+        }
         mDetector = new GestureDetectorCompat(this,this);
         mDetector.setOnDoubleTapListener(this);
 

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
@@ -20,7 +20,7 @@ package ca.mcgill.a11y.image.renderers;
 import static ca.mcgill.a11y.image.DataAndMethods.backButton;
 import static ca.mcgill.a11y.image.DataAndMethods.confirmButton;
 import static ca.mcgill.a11y.image.DataAndMethods.displayGraphic;
-import static ca.mcgill.a11y.image.DataAndMethods.followingUp;
+//import static ca.mcgill.a11y.image.DataAndMethods.followingUp;
 import static ca.mcgill.a11y.image.DataAndMethods.keyMapping;
 import static ca.mcgill.a11y.image.DataAndMethods.silentStart;
 import static ca.mcgill.a11y.image.DataAndMethods.update;
@@ -86,14 +86,14 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
 
         });
 
-        followingUp.observe(this,new Observer<Boolean>() {
+        /*followingUp.observe(this,new Observer<Boolean>() {
             @Override
             public void onChanged(Boolean changedVal) {
                 if (!changedVal){
                     startService(new Intent(getApplicationContext(), PollingService.class));
                 }
             }
-        });
+        });*/
     }
 
 
@@ -251,9 +251,9 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
         if (!silentStart)
             DataAndMethods.speaker("Exploration mode", TextToSpeech.QUEUE_FLUSH);
 
-        if (!followingUp.getValue()) {
+        //if (!followingUp.getValue()) {
             startService(new Intent(getApplicationContext(), PollingService.class));
-        }
+        //}
         mDetector = new GestureDetectorCompat(this,this);
         mDetector.setOnDoubleTapListener(this);
 

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/Guidance.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/Guidance.java
@@ -70,7 +70,7 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
             @Override
             public void onChanged(Boolean changedVal) {
                 if (changedVal && DataAndMethods.image != null){
-                    displayGraphic(confirmButton, "Guidance");
+                    displayGraphic(confirmButton, "Guidance", false);
                 }
             }
 
@@ -100,12 +100,12 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
 
                 case "OK":
                     if (DataAndMethods.image!= null)
-                        DataAndMethods.displayGraphic(confirmButton, "Guidance");
+                        DataAndMethods.displayGraphic(confirmButton, "Guidance", false);
                     return false;
 
                 case "CANCEL":
                     if (DataAndMethods.image!= null)
-                        DataAndMethods.displayGraphic(backButton, "Guidance");
+                        DataAndMethods.displayGraphic(backButton, "Guidance", false);
                     return false;
                 default:
                     Log.d("KEY EVENT", event.toString());

--- a/app/src/main/java/ca/mcgill/a11y/image/request_formats/ResponseFormat.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/request_formats/ResponseFormat.java
@@ -26,6 +26,8 @@ public class ResponseFormat {
     public long timestamp;
     @SerializedName("renderings")
     public Rendering[] renderings=null;
+    @SerializedName("graphicBlob")
+    public String graphicBlob;
 
     public class Rendering{
         @SerializedName("description")


### PR DESCRIPTION
Make changes to the original implementation of followup queries to work with classroom mode. This involves keeping track of the ongoing follow up call separately from normal queries, enabling silent exits from the followup activity, and modifying the History object and the way history is recorded. 