### PR TITLE
Fix XPath query that adds transform attributes

### DIFF
--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -1060,7 +1060,7 @@ public class DataAndMethods {
                 Node n = nodeslist.item(i);
                 ((Element)n).setAttribute("transform", "translate("+translations[0]+" "+translations[1]+")");
             }
-            nodeslist=(NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@data-image-layer]) and not(descendant::*[@data-image-layer])and not(ancestor::metadata)] ", doc, XPathConstants.NODESET);
+            nodeslist=(NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@data-image-layer]) and not(descendant::*[@data-image-layer])and not(ancestor::metadata) and not(self::svg)] ", doc, XPathConstants.NODESET);
             for(int i = 0 ; i < nodeslist.getLength() ; i ++) {
                 Node n = nodeslist.item(i);
                 ((Element)n).setAttribute("transform", "translate("+translations[0]+" "+translations[1]+")");


### PR DESCRIPTION
Earlier one of the XPath queries that selects nodes to add the `transform` attribute also selected the `svg` node for graphics that do not have layers, resulting in invalid SVGs. 
This change makes sure that the XPath query does not select the `svg` node. 

This PR potentially addresses #66. 
