### PR TITLE
Remove ROI selection steps in followup query request process

### DIFF
--- a/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
@@ -72,7 +72,8 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                          SAXException e) {
                     throw new RuntimeException(e);
                 }
-                DataAndMethods.speaker(getResources().getString(R.string.received_query_0)+query+getResources().getString(R.string.received_query_1), TextToSpeech.QUEUE_FLUSH);
+                DataAndMethods.speaker(getResources().getString(R.string.received_query_0)+query+" "+getResources().getString(R.string.received_query_1_temp), TextToSpeech.QUEUE_FLUSH);
+                        //getResources().getString(R.string.received_query_1), TextToSpeech.QUEUE_FLUSH);
                 break;
             case 1:
                 //Log.d("STATE", "State 1");
@@ -119,6 +120,8 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                         break;
                     default:
                         DataAndMethods.pingsPlayer(R.raw.image_error);
+                        DataAndMethods.update.setValue(true);
+                        finish();
                         break;
                 }
                 return true;
@@ -228,7 +231,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
     public boolean onDoubleTap(MotionEvent event) {
         Log.d("GESTURE!", "onDoubleTap: " + event.toString());
         Integer [] pins=DataAndMethods.pinCheck(event.getX(), event.getY());
-        switch(state){
+        /*switch(state){
             case 0:
                 region = new Integer[]{0, 0, 0, 0};
                 region[0] = pins[0];
@@ -257,7 +260,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                 break;
             default:
                 break;
-        }
+        }*/
         return true;
     }
 

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -54,4 +54,7 @@
     <string name="received_query_1">Double-cliquez sur le coin supérieur gauche de la région qui vous intéresse ou appuyez sur la touche de confirmation pour lancer une requête sans sélection.</string>
     <string name="state_1">Double-cliquer sur le coin inférieur droit de la région d\'intérêt ou appuyer sur \'confirmer\' pour procéder sans sélection. Appuyez sur \'annuler\' pour revenir à la page précédente.</string>
     <string name="state_2">Appuyer sur \'confirmer\' pour demander la région sélectionnée. Appuyer sur \'annuler\' pour revenir à la sélection de la région</string>
+
+    <!--Temporary FollowUpQuery strings-->
+    <string name="received_query_1_temp">Appuyer sur \'confirmer\' lancer une requête. Appuyer sur \'annuler\' pour sortir.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,4 +54,9 @@
     <string name="received_query_1">Double-click on top left corner of region of interest or press confirm to query without selection</string>
     <string name="state_1">Double-click on bottom right corner of region of interest or press confirm to proceed without selection. Press cancel to return"</string>
     <string name="state_2">Press \'confirm\' to query for selected region. Press cancel to return to region selection"</string>
+
+    <!--Temporary FollowUpQuery strings-->
+    <string name="received_query_1_temp">Press confirm to make query. Press cancel to exit</string>
+
+
 </resources>


### PR DESCRIPTION
The code resulting in advancement of the FollowUpQuery Activity trough the ROI selection states has been commented out and a temporary string has been added to remove the ROI selection steps from the followup query process. Temporary strings have been added to convey the current process to the user. 

These changes will need to be undone when backend components that support ROI based followup queries are implemented. Closes #69. 