### PR TITLE
Handle history and followup requests for maps and custom graphics

### DIFF
--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -928,6 +928,8 @@ public class DataAndMethods {
                                     }
                                     JSONObject request = new JSONObject(json);
                                     history.updateHistory(request);
+                                } else {
+                                    history.clearHistory();
                                 }
                                 image = decrypt(image, context.getString(R.string.password));
                             }

--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -55,6 +55,7 @@ import androidx.lifecycle.MutableLiveData;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.scand.svg.SVGHelper;
 
 import org.json.JSONArray;
@@ -917,9 +918,12 @@ public class DataAndMethods {
                                         json = gson.toJson(rq);
                                     } else if (resource.coords != null) {
                                         MapRequestFormat rq = new MapRequestFormat();
-                                        Double lat = Double.valueOf(decrypt(resource.coords.lat, context.getString(R.string.password)));
-                                        Double lon = Double.valueOf(decrypt(resource.coords.lon, context.getString(R.string.password)));
-                                        rq.setValues(lat, lon);
+                                        //Double lat = Double.valueOf(decrypt(resource.coords.lat, context.getString(R.string.password)));
+                                        String coords = decrypt(resource.coords, context.getString(R.string.password));
+                                        //Double lon = Double.valueOf(decrypt(resource.coords.lon, context.getString(R.string.password)));
+                                        JsonObject obj = new JsonParser().parse(coords).getAsJsonObject();
+                                        rq.setValues(Double.valueOf(String.valueOf(obj.get("latitude"))),
+                                                Double.valueOf(String.valueOf(obj.get("longitude"))));
                                         json = gson.toJson(rq);
                                     } else if ( resource.placeID != null) {
                                         MapRequestFormat rq = new MapRequestFormat();
@@ -1086,7 +1090,7 @@ public class DataAndMethods {
                 Node n = nodeslist.item(i);
                 ((Element)n).setAttribute("transform", "translate("+translations[0]+" "+translations[1]+")");
             }
-            nodeslist=(NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@data-image-layer]) and not(descendant::*[@data-image-layer])and not(ancestor::metadata)] ", doc, XPathConstants.NODESET);
+            nodeslist=(NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@data-image-layer]) and not(descendant::*[@data-image-layer])and not(ancestor::metadata) and not(self::svg)] ", doc, XPathConstants.NODESET);
             for(int i = 0 ; i < nodeslist.getLength() ; i ++) {
                 Node n = nodeslist.item(i);
                 ((Element)n).setAttribute("transform", "translate("+translations[0]+" "+translations[1]+")");

--- a/app/src/main/java/ca/mcgill/a11y/image/History.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/History.java
@@ -29,4 +29,8 @@ public class History{
         this.response = response;
     }
 
+    public void clearHistory() {
+        this.type = null;
+        this.request = null;
+    }
 }

--- a/app/src/main/java/ca/mcgill/a11y/image/History.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/History.java
@@ -19,7 +19,7 @@ public class History{
     public void updateHistory(JSONObject jsonObject) throws JSONException {
         if (jsonObject.has("graphic")){
             this.type = "Photo";
-        } else if (jsonObject.has("coordinates")) {
+        } else if (jsonObject.has("coordinates") || jsonObject.has("placeID")) {
             this.type = "Map";
         }
         this.request = jsonObject;

--- a/app/src/main/java/ca/mcgill/a11y/image/request_formats/MapRequestFormat.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/request_formats/MapRequestFormat.java
@@ -26,6 +26,8 @@ public class MapRequestFormat extends BaseRequestFormat {
     private Coordinates coords=new Coordinates();
     @SerializedName("url")
     private String url= "https://example-map-url.com";
+    @SerializedName("placeID")
+    public String placeID;
 
     public class Coordinates{
         @SerializedName("latitude")
@@ -36,5 +38,8 @@ public class MapRequestFormat extends BaseRequestFormat {
     public void setValues(Double lat, Double lon) throws JSONException {
         this.coords.lat = lat;
         this.coords.lon = lon;
+    }
+    public void setPlaceID(String placeID){
+        this.placeID = placeID;
     }
 }

--- a/app/src/main/java/ca/mcgill/a11y/image/request_formats/ResponseFormat.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/request_formats/ResponseFormat.java
@@ -28,6 +28,10 @@ public class ResponseFormat {
     public Rendering[] renderings=null;
     @SerializedName("graphicBlob")
     public String graphicBlob;
+    @SerializedName("coordinates")
+    public Coordinates coords= null;
+    @SerializedName("placeID")
+    public String placeID;
 
     public class Rendering{
         @SerializedName("description")
@@ -45,5 +49,12 @@ public class ResponseFormat {
 
         @SerializedName("text")
         public String text;
+    }
+
+    public class Coordinates{
+        @SerializedName("latitude")
+        public String lat;
+        @SerializedName("longitude")
+        public String lon;
     }
 }

--- a/app/src/main/java/ca/mcgill/a11y/image/request_formats/ResponseFormat.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/request_formats/ResponseFormat.java
@@ -29,7 +29,7 @@ public class ResponseFormat {
     @SerializedName("graphicBlob")
     public String graphicBlob;
     @SerializedName("coordinates")
-    public Coordinates coords= null;
+    public String coords;
     @SerializedName("placeID")
     public String placeID;
 
@@ -51,10 +51,4 @@ public class ResponseFormat {
         public String text;
     }
 
-    public class Coordinates{
-        @SerializedName("latitude")
-        public String lat;
-        @SerializedName("longitude")
-        public String lon;
-    }
 }

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -48,6 +48,8 @@
     <string name="guidance_unavailable">Aucun mode de conseils disponible</string>
     <string name="tactile_response">Réponse tactile reçue. Appuyez sur la touche de confirmation pour l\'afficher. Appuyer sur annuler pour l\'ignorer.</string>
     <string name="unknown_type">Réponse reçue dans un type qui n\'est pas encore traité</string>
+    <string name="followup_no_support">La demande de suivi n\'est pas encore prise en charge pour cette image.</string>
+    <string name="followup_no_support_maps">La demande de suivi n\'est pas encore prise en charge pour les cartes.</string>
     <!--
     FollowUpQuery-->
     <string name="received_query_0">Requête reçue: "</string>

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="server_url" translatable="false">https://monarch.unicorn.cim.mcgill.ca/</string>
+    <string name="server_url" translatable="false">https://unicorn.cim.mcgill.ca/image/monarch/</string>
     <string name="locale" translateable="false">en</string>
     <!-- Uncomment for French: <string name="locale" translatable="false">fr-CA</string>-->
     <string name="share_code" translatable="false">362826</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,8 @@
     <string name="guidance_unavailable">No guidance mode available</string>
     <string name="tactile_response">Tactile response received. Press confirm to view it. Press cancel to ignore.</string>
     <string name="unknown_type">Response received in type that is not handled yet.</string>
+    <string name="followup_no_support">Follow up request is not yet supported for this graphic.</string>
+    <string name="followup_no_support_maps">Follow up request is not yet supported for maps.</string>
 
     <!--FollowUpQuery-->
     <string name="received_query_0">"Query received: "</string>


### PR DESCRIPTION
Maps and custom hand-drawn graphics are now supported in history. For followup requests, client indicates that it does not handle requests for maps and custom graphics. 

Tested using extension requests for both a photograph and a map.  Similar behavior is expected for requests from the TAT. Also noted that the application defaults to custom graphic behavior if source data is not provided for either maps or photographs. 

This PR closes #67 