### PR TITLE
Move urls config to setup.xml

### DIFF
--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -726,9 +726,7 @@ public class DataAndMethods {
         PhotoRequestFormat req= new PhotoRequestFormat();
         req.setValues(base64, dims);*/
         PhotoRequestFormat req = createPhotoRequest(folderName);
-        Retrofit retrofit = requestBuilder(60, 60, "https://unicorn.cim.mcgill.ca/image/");
-                //"https://image.a11y.mcgill.ca/");
-
+        Retrofit retrofit = requestBuilder(60, 60, context.getString(R.string.photos_server_url));
         MakeRequest makereq= retrofit.create(MakeRequest.class);
         Call<ResponseFormat> call= makereq.makePhotoRequest(req);
         //history.updateHistory(req);
@@ -784,8 +782,7 @@ public class DataAndMethods {
     public static void getMap(Double lat, Double lon) throws JSONException {
         MapRequestFormat req= new MapRequestFormat();
         req.setValues(lat, lon);
-        Retrofit retrofit = requestBuilder(60, 60, // "https://unicorn.cim.mcgill.ca/image/" );
-                "https://image.a11y.mcgill.ca/");
+        Retrofit retrofit = requestBuilder(60, 60, context.getString(R.string.maps_server_url));
         MakeRequest makereq= retrofit.create(MakeRequest.class);
         Call<ResponseFormat> call= makereq.makeMapRequest(req);
         //history.updateHistory(req);
@@ -794,10 +791,10 @@ public class DataAndMethods {
 
     // fetches updates from server if they exist
     public static void checkForUpdate() throws IOException, JSONException {
-        Retrofit retrofit = requestBuilder(60, 60, context.getString(R.string.server_url));
+        Retrofit retrofit = requestBuilder(60, 60, context.getString(R.string.classroom_server_url));
 
         MakeRequest makereq= retrofit.create(MakeRequest.class);
-        Call<ResponseFormat> call= makereq.checkForUpdates(context.getString(R.string.server_url)+"display/"+channelSubscribed);
+        Call<ResponseFormat> call= makereq.checkForUpdates(context.getString(R.string.classroom_server_url)+"display/"+channelSubscribed);
         makeServerCall(call, false);
     }
 
@@ -1396,8 +1393,7 @@ public class DataAndMethods {
     // make follow up query to server
     public static void sendFollowUpQuery(String query, Integer[] region) throws JSONException, IOException {
         Float[] focus = null;
-        Retrofit retrofit = requestBuilder(60, 60, "https://unicorn.cim.mcgill.ca/image/" );
-                //"https://image.a11y.mcgill.ca/");
+        Retrofit retrofit = requestBuilder(60, 60, context.getString(R.string.followup_server_url));
         MakeRequest makereq= retrofit.create(MakeRequest.class);
         Call<ResponseFormat> call = null;
 

--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -794,7 +794,7 @@ public class DataAndMethods {
         Retrofit retrofit = requestBuilder(60, 60, context.getString(R.string.classroom_server_url));
 
         MakeRequest makereq= retrofit.create(MakeRequest.class);
-        Call<ResponseFormat> call= makereq.checkForUpdates(context.getString(R.string.classroom_server_url)+"display/"+channelSubscribed);
+        Call<ResponseFormat> call= makereq.checkForUpdates(context.getString(R.string.classroom_server_url)+"monarch/display/"+channelSubscribed);
         makeServerCall(call, false);
     }
 

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!--<string name="server_url" translatable="false">https://unicorn.cim.mcgill.ca/image/monarch/</string>-->
-    <string name="server_url" translatable="false">https://image.a11y.mcgill.ca/monarch/</string>
-    <!--<string name="server_url" translatable="false">http://15.222.182.10/monarch/</string>-->
+    <!--<string name="classroom_server_url" translatable="false">https://unicorn.cim.mcgill.ca/image/monarch/</string>-->
+    <string name="classroom_server_url" translatable="false">https://image.a11y.mcgill.ca/monarch/</string>
+    <!--<string name="classroom_server_url" translatable="false">http://15.222.182.10/monarch/</string>-->
+    <string name="followup_server_url" translatable="false">https://image.a11y.mcgill.ca/</string>
+    <string name="photos_server_url" translatable="false">https://image.a11y.mcgill.ca/</string>
+    <string name="maps_server_url" translatable="false">https://image.a11y.mcgill.ca/</string>
     <string name="locale" translateable="false">en</string>
     <!-- Uncomment for French: <string name="locale" translatable="false">fr-CA</string>-->
     <string name="share_code" translatable="false">766323</string>

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!--<string name="classroom_server_url" translatable="false">https://unicorn.cim.mcgill.ca/image/monarch/</string>-->
-    <string name="classroom_server_url" translatable="false">https://image.a11y.mcgill.ca/monarch/</string>
-    <!--<string name="classroom_server_url" translatable="false">http://15.222.182.10/monarch/</string>-->
+    <!--<string name="classroom_server_url" translatable="false">https://unicorn.cim.mcgill.ca/image/</string>-->
+    <string name="classroom_server_url" translatable="false">https://image.a11y.mcgill.ca/</string>
+    <!--<string name="classroom_server_url" translatable="false">http://15.222.182.10/</string>-->
     <string name="followup_server_url" translatable="false">https://image.a11y.mcgill.ca/</string>
     <string name="photos_server_url" translatable="false">https://image.a11y.mcgill.ca/</string>
     <string name="maps_server_url" translatable="false">https://image.a11y.mcgill.ca/</string>


### PR DESCRIPTION
This PR includes the following changes: 
1. server_url in setup.xml was renamed to classroom_server_url
2. New entries were created in setup.xml to configure urls for followup, maps and photos requests. This will make them less likely to be missed. (_The urls have been maintained as separate values because we have had cases in the past where we wanted to change just one of them but not the others. If it is more advisable to collapse them into a single variable, I am open to the option._)

This change was prompted as a result of accidentally making followup requests to test instead of prod server.

TESTING:
Tested by making a request to classroom mode, photo mode, maps mode, and a followup request for the former 2 to verify that the urls have been correctly configured. 