### PR TITLE
Update filtering in XPath queries checking display attribute

### DIFF
--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -504,7 +504,7 @@ public class DataAndMethods {
             speaker(res.getString(R.string.full_image), TextToSpeech.QUEUE_FLUSH);
         }
 
-        NodeList detail= (NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@display]) and not(descendant::*[@display]) and (self::*[@data-image-zoom])]", doc, XPathConstants.NODESET);
+        NodeList detail= (NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@display = 'none']) and not(descendant::*[@display = 'none']) and (self::*[@data-image-zoom])]", doc, XPathConstants.NODESET);
         for(int i = 0 ; i < detail.getLength() ; i ++) {
             Node node = detail.item(i);
             Float zoomLevel= Float.valueOf(((Element)node).getAttribute("data-image-zoom"));
@@ -612,7 +612,7 @@ public class DataAndMethods {
         XPath xPath = XPathFactory.newInstance().newXPath();
         // query elements that are in the present layer AND have element level descriptions (NOT layer level descriptions)
         // Assuming that only elements with short description can have a long description here. Is this assumption safe?!
-        NodeList nodeslist=(NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@display]) and not(descendant::*[@display]) and (not(self::*[@data-image-layer]) or not(child::*))  and ((self::*[@aria-labelledby] or self::*[@aria-label]) or parent::*[@data-image-layer])]", doc, XPathConstants.NODESET);        // temporary var for objects tags
+        NodeList nodeslist=(NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@display = 'none']) and not(descendant::*[@display = 'none']) and (not(self::*[@data-image-layer]) or not(child::*))  and ((self::*[@aria-labelledby] or self::*[@aria-label]) or parent::*[@data-image-layer])]", doc, XPathConstants.NODESET);        // temporary var for objects tags
         String[] layerTags=new String[brailleServiceObj.getDotPerLineCount()*brailleServiceObj.getDotLineCount()];
         // temporary var for objects long descriptions
         String[] layerDesc=new String[brailleServiceObj.getDotPerLineCount()*brailleServiceObj.getDotLineCount()];
@@ -844,7 +844,7 @@ public class DataAndMethods {
             Node node = nodeslist.item(i);
             ((Element)node).setAttribute("display","none");
         }
-        nodeslist= (NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@display]) and not(descendant::*[@display]) and (self::*[@data-image-zoom])]", doc, XPathConstants.NODESET);
+        nodeslist= (NodeList)xPath.evaluate("//*[not(ancestor-or-self::*[@display = 'none']) and not(descendant::*[@display = 'none']) and (self::*[@data-image-zoom])]", doc, XPathConstants.NODESET);
         for(int i = 0 ; i < nodeslist.getLength() ; i ++) {
             Node node = nodeslist.item(i);
             Float zoomLevel= Float.valueOf(((Element)node).getAttribute("data-image-zoom"));


### PR DESCRIPTION
Updated XPath queries as per detailed in #76. 

TESTING: Tested after reverting changes made in Shared-Reality-Lab/IMAGE-TactileAuthoring#18.
After toggling layer visibility, the first layer of the SVG appeared as follows in the Monarch log (i.e. the display="inline" was retained):
`<g aria-label="people" data-image-layer="Layer 1" display="inline"`

The labels worked as expected on this layer with the application version in this PR.

This PR closes #77. 

