### PR TITLE
Enable logging to file

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,4 +60,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:3.9.0'
     // Locale
     implementation 'androidx.appcompat:appcompat:1.6.0-alpha01'
+    // Logging
+    implementation 'com.jakewharton.timber:timber:5.0.1'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
 }

--- a/app/src/main/java/ca/mcgill/a11y/image/BaseActivity.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/BaseActivity.java
@@ -175,12 +175,16 @@ public class BaseActivity extends AppCompatActivity {
                     return false;
             }
         } catch (IOException e) {
+            Timber.e(e, "EXCEPTION");
             throw new RuntimeException(e);
         } catch (XPathExpressionException e) {
+            Timber.e(e, "EXCEPTION");
             throw new RuntimeException(e);
         } catch (ParserConfigurationException e) {
+            Timber.e(e, "EXCEPTION");
             throw new RuntimeException(e);
         } catch (SAXException e) {
+            Timber.e(e, "EXCEPTION");
             throw new RuntimeException(e);
         }
     }

--- a/app/src/main/java/ca/mcgill/a11y/image/BaseActivity.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/BaseActivity.java
@@ -75,6 +75,8 @@ import java.util.regex.Pattern;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 
+import timber.log.Timber;
+
 // Base activity which is extended by all other activities. Implements functionality common to all/most activities
 public class BaseActivity extends AppCompatActivity {
     static BrailleDisplay brailleServiceObj = null;
@@ -132,7 +134,7 @@ public class BaseActivity extends AppCompatActivity {
         try {
             switch (keyMapping.getOrDefault(keyCode, "default")) {
                 case "ZOOM OUT":
-                    Log.d("KEY EVENT", event.toString());
+                    Timber.d("KEY EVENT: "+ event.toString());
                     if (!DataAndMethods.zoomingOut) {
                         DataAndMethods.speaker(getResources().getString(R.string.on_zoom_mode), TextToSpeech.QUEUE_FLUSH);
                         DataAndMethods.zoomingOut = true;
@@ -143,7 +145,7 @@ public class BaseActivity extends AppCompatActivity {
                     }
                     return true;
                 case "ZOOM IN":
-                    Log.d("KEY EVENT", event.toString());
+                    Timber.d("KEY EVENT: "+ event.toString());
                     if (!DataAndMethods.zoomingIn) {
                         DataAndMethods.speaker(getResources().getString(R.string.on_zoom_mode), TextToSpeech.QUEUE_FLUSH);
                         DataAndMethods.zoomingIn = true;
@@ -158,7 +160,7 @@ public class BaseActivity extends AppCompatActivity {
                 case "DPAD LEFT":
                 case "DPAD RIGHT":
                     if (DataAndMethods.zoomVal > 100 && (DataAndMethods.zoomingIn || DataAndMethods.zoomingOut)) {
-                        Log.d("DPAD", String.valueOf(keyCode));
+                        Timber.d("DPAD: "+ String.valueOf(keyCode));
                         DataAndMethods.pan(keyCode, getLocalClassName());
                     }
                     return false;
@@ -169,7 +171,7 @@ public class BaseActivity extends AppCompatActivity {
                         finish();
                     return false;
                 default:
-                    Log.d("KEY EVENT", event.toString());
+                    Timber.d("KEY EVENT: "+ event.toString());
                     return false;
             }
         } catch (IOException e) {

--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -122,6 +122,7 @@ import retrofit2.Callback;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
+import timber.log.Timber;
 
 public class DataAndMethods {
     // SVG data received from response 
@@ -232,7 +233,7 @@ public class DataAndMethods {
                 public void onInit(int status) {
 
                     if (status != TextToSpeech.SUCCESS) {
-                        Log.e("error", "Initialization Failed!" + status);
+                        Timber.e("error: "+ "Initialization Failed!" + status);
                     } else {
                         tts.setLanguage(Locale.forLanguageTag(res.getString(R.string.locale)));
                         tts.setOnUtteranceProgressListener(new UtteranceProgressListener() {
@@ -281,7 +282,7 @@ public class DataAndMethods {
 
                 @Override
                 public void onBeginningOfSpeech() {
-                    Log.d("SPEECHREC", "Listening");
+                    Timber.d("SPEECHREC: "+ "Listening");
                     //Toast toast = Toast.makeText(getApplicationContext() , "Listening...", Toast.LENGTH_SHORT);
                     //toast.show();
                 }
@@ -303,7 +304,7 @@ public class DataAndMethods {
 
                 @Override
                 public void onError(int i) {
-                    Log.d("SPEECHREC", String.valueOf(i));
+                    Timber.d("SPEECHREC: "+String.valueOf(i));
                     switch (i) {
                         case SpeechRecognizer.ERROR_NO_MATCH:
                             DataAndMethods.speaker(res.getString(R.string.text_error), TextToSpeech.QUEUE_FLUSH);
@@ -331,7 +332,14 @@ public class DataAndMethods {
                 }
             });
         }
+        //Log.d("FILE", String.valueOf(context.getFilesDir()));
+        File logDir = new File(context.getFilesDir(), "logs");
+
+        // Create and plant the FileTree
+        Timber.plant(new FileTree(logDir.getAbsolutePath()));
+
     }
+
 
     public static void onShowFollowUp() throws IOException, XPathExpressionException, ParserConfigurationException, SAXException {
         Intent myIntent = new Intent(DataAndMethods.context, ShowFollowUp.class);
@@ -359,11 +367,11 @@ public class DataAndMethods {
             }
             else if (history.type.equals("Map")) {
                 speaker(context.getString(R.string.followup_no_support_maps), TextToSpeech.QUEUE_FLUSH);
-                Log.d("onVoiceRecognitionResults", "NOT HANDLED YET!");
+                Timber.d("onVoiceRecognitionResults: "+ "NOT HANDLED YET!");
             }
         }
         else {
-            Log.d("onVoiceRecognitionResults", "NOT HANDLED YET!");
+            Timber.d("onVoiceRecognitionResults: "+"NOT HANDLED YET!");
             speaker(context.getString(R.string.followup_no_support), TextToSpeech.QUEUE_FLUSH);
         }
     }
@@ -432,7 +440,7 @@ public class DataAndMethods {
         }
         catch(TransformerException ex)
         {
-            Log.d("ERROR", "Write Failed");
+            Timber.d("ERROR: "+ "Write Failed");
             return null;
         }
     }
@@ -975,7 +983,7 @@ public class DataAndMethods {
                         update.setValue(true);
                     }
                     else{
-                        Log.d("CACHE", "Fetching from cache!");
+                        Timber.d("CACHE: "+ "Fetching from cache!");
                     }
                 }
                 // This occurs when there is no rendering returned
@@ -1002,7 +1010,7 @@ public class DataAndMethods {
                 // This text is not read out when a request is cancelled as there is expected to be
                 // an ongoing request and can be confused as a result of that request.
                 // Causes interrupted requests to die silently!
-                Log.d("RESPONSE", "FAILED!");
+                Timber.d("RESPONSE: "+ "FAILED!");
                 if (!call.isCanceled()){
                     pingsPlayer(R.raw.image_error);
                 }
@@ -1325,7 +1333,7 @@ public class DataAndMethods {
             mp=MediaPlayer.create(context, file);
             mp.start();
         } catch (Exception e) {
-            Log.d("ERROR", e.toString());
+            Timber.d("ERROR: "+ e.toString());
         }
     }
 

--- a/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/DataAndMethods.java
@@ -402,6 +402,7 @@ public class DataAndMethods {
             brailleServiceObj.display(DataAndMethods.getGuidanceBitmaps(DataAndMethods.getfreshDoc(), !silentStart));
         }}
         catch(IOException | SAXException | ParserConfigurationException | XPathExpressionException e) {
+            Timber.e(e, "EXCEPTION");
             throw new RuntimeException(e);
         }
     }
@@ -438,9 +439,9 @@ public class DataAndMethods {
             transformer.transform(domSource, result);
             return writer.toString();
         }
-        catch(TransformerException ex)
+        catch(TransformerException e)
         {
-            Timber.d("ERROR: "+ "Write Failed");
+            Timber.e(e, "EXCEPTION");
             return null;
         }
     }
@@ -535,6 +536,7 @@ public class DataAndMethods {
                     // Generally occurs with a little delay following the tactile rendering
                     pingsPlayer(R.raw.ping);
                 } catch (XPathExpressionException | IOException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
             }
@@ -990,14 +992,17 @@ public class DataAndMethods {
                 catch (IOException | ParserConfigurationException | SAXException |
                        XPathExpressionException e) {
                     //history.setHistory(false);
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 } catch (ArrayIndexOutOfBoundsException | NullPointerException e){
+                    Timber.e(e, "EXCEPTION");
                     pingsPlayer(R.raw.image_error);
                     /*if (followingUp.getValue()){
                         followingUp.setValue(false);
                     }*/
                     //history.setHistory(false);
                 } catch (Exception e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
             }
@@ -1333,7 +1338,7 @@ public class DataAndMethods {
             mp=MediaPlayer.create(context, file);
             mp.start();
         } catch (Exception e) {
-            Timber.d("ERROR: "+ e.toString());
+            Timber.e(e, "EXCEPTION");
         }
     }
 
@@ -1354,8 +1359,10 @@ public class DataAndMethods {
                     showAll = true;
                     pingsPlayer(R.raw.ping);
                 } catch (XPathExpressionException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 } catch (IOException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
             }

--- a/app/src/main/java/ca/mcgill/a11y/image/FileTree.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FileTree.java
@@ -22,6 +22,7 @@ import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.PublishSubject;
 import timber.log.Timber;
 
+// inspired and modified form Logging to disk reactively on Android by Karn Saheb on Medium
 public class FileTree extends Timber.Tree {
 
     private static final SimpleDateFormat LOG_LINE_TIME_FORMAT =
@@ -160,12 +161,5 @@ public class FileTree extends Timber.Tree {
                 }
             }
         }
-    }
-
-
-     //Gets the file extension from a file name.
-    private String getFileExtension(String fileName) {
-        int lastDot = fileName.lastIndexOf('.');
-        return (lastDot >= 0) ? fileName.substring(lastDot + 1) : "";
     }
 }

--- a/app/src/main/java/ca/mcgill/a11y/image/FileTree.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FileTree.java
@@ -53,7 +53,7 @@ public class FileTree extends Timber.Tree {
                 .observeOn(Schedulers.computation())
                 .doAfterNext(logElement -> {
                     processedCount++;
-                    if (processedCount % 20 == 0) {
+                    if ((processedCount % 20 == 0)|| (logElement.priority >= Log.ERROR)) {
                         flush.onNext(1L);
                     }
                 })

--- a/app/src/main/java/ca/mcgill/a11y/image/FileTree.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FileTree.java
@@ -1,0 +1,239 @@
+package ca.mcgill.a11y.image;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
+
+import io.reactivex.Observable;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.PublishSubject;
+import timber.log.Timber;
+
+public class FileTree extends Timber.Tree {
+
+    private static final SimpleDateFormat LOG_LINE_TIME_FORMAT =
+            new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
+
+    private static final String LOG_FILE_NAME = "logs.txt";
+    private static final String[] LOG_LEVELS = {
+            "VERBOSE", "DEBUG", "INFO", "WARN", "ERROR", "ASSERT"
+    };
+
+    private final PublishSubject<LogElement> logBuffer = PublishSubject.create();
+    private static final BehaviorSubject<Long> flush = BehaviorSubject.create();
+
+    private int processedCount = 0;
+    private final String filePath;
+    private Disposable logSubscription;
+    private static final long LOG_FILE_RETENTION = TimeUnit.DAYS.toMillis(7); // for example
+    private static final SimpleDateFormat LOG_FILE_TIME_FORMAT =
+            new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US);
+    private static final long MAX_LOG_FILE_SIZE = 1024 * 1024;
+
+    public FileTree(String filePath) {
+        this.filePath = filePath;
+
+        logSubscription = logBuffer
+                .observeOn(Schedulers.computation())
+                .doAfterNext(logElement -> {
+                    processedCount++;
+                    if (processedCount % 20 == 0) {
+                        flush.onNext(1L);
+                    }
+                })
+                .buffer(Observable.merge(
+                        flush,
+                        Observable.interval(5, TimeUnit.MINUTES)
+                ))
+                .subscribeOn(Schedulers.io())
+                /*.subscribe(logElements -> {
+                    try {
+                        File f = getFile(filePath, LOG_FILE_NAME);
+                        FileWriter fw = new FileWriter(f, true);
+                        for (LogElement el : logElements) {
+                            fw.append(el.date).append("\t")
+                                    .append(LOG_LEVELS[el.priority]).append("\t")
+                                    .append(el.message != null ? el.message : "").append("\n");
+                        }
+                        fw.flush();
+                        fw.close();
+                        // Rotate logs right after writing a new batch
+                        rotateLogs(filePath, LOG_FILE_NAME);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                });*/
+                .subscribe(logElements -> {
+                    try {
+                        File f = getFile(filePath, LOG_FILE_NAME);
+
+                        // ✅ Rotate if log file exceeds max size BEFORE writing
+                        if (f.exists() && f.length() >= MAX_LOG_FILE_SIZE) {
+                            rotateLogs(filePath, LOG_FILE_NAME);
+                        }
+
+                        try (FileWriter fw = new FileWriter(f, true)) {
+                            for (LogElement el : logElements) {
+                                fw.append(el.date).append("\t")
+                                        .append(LOG_LEVELS[el.priority]).append("\t")
+                                        .append(el.message != null ? el.message : "").append("\n");
+                            }
+                            fw.flush();
+                        }
+
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                });
+    }
+
+    @Override
+    protected void log(int priority, String tag, String message, Throwable t) {
+        logBuffer.onNext(new LogElement(
+                LOG_LINE_TIME_FORMAT.format(new Date()),
+                priority,
+                message
+        ));
+    }
+
+    public static class LogElement {
+        public final String date;
+        public final int priority;
+        public final String message;
+
+        public LogElement(String date, int priority, String message) {
+            this.date = date;
+            this.priority = priority;
+            this.message = message;
+        }
+    }
+
+    // Helper method to get or create the log file
+    private File getFile(String dirPath, String fileName) {
+        File dir = new File(dirPath);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+        File file = new File(dir, fileName);
+        try {
+            if (!file.exists()) {
+                file.createNewFile();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return file;
+    }
+
+    /**
+     * Rotates the given log file: compresses it, truncates it, and deletes old compressed files.
+     */
+    /*private void rotateLogs(String path, String name) throws IOException {
+        File file = getFile(path, name);
+
+        if (!compress(file)) {
+            throw new IOException("Failed to compress file for rotation: " + file.getAbsolutePath());
+        }
+
+        // Truncate the file to zero bytes
+        new PrintWriter(file).close();
+
+        long currentTime = System.currentTimeMillis();
+
+        File[] files = file.getParentFile().listFiles();
+        if (files != null) {
+            for (File f : files) {
+                String ext = getFileExtension(f.getName()).toLowerCase(Locale.ROOT);
+                if (ext.equals("gz") && f.lastModified() + LOG_FILE_RETENTION < currentTime) {
+                    f.delete();
+                }
+            }
+        }
+    }*/
+
+    private void rotateLogs(String path, String name) {
+        File logFile = getFile(path, name);
+        if (!logFile.exists() || logFile.length() == 0) {
+            return;
+        }
+
+        // Create rotated file name with timestamp
+        String rotatedName = name.substring(0, name.lastIndexOf('.')) +
+                "_" + LOG_FILE_TIME_FORMAT.format(new Date()) + ".txt";
+        File rotatedFile = new File(logFile.getParentFile(), rotatedName);
+
+        boolean renamed = logFile.renameTo(rotatedFile);
+        if (!renamed) {
+            System.err.println("Failed to rotate log file");
+            return;
+        }
+
+        try {
+            logFile.createNewFile(); // New empty log file
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        // Clean up old rotated files
+        long currentTime = System.currentTimeMillis();
+        File[] files = logFile.getParentFile().listFiles();
+        if (files != null) {
+            for (File f : files) {
+                if (f.getName().startsWith(name.substring(0, name.lastIndexOf('.')) + "_") &&
+                        f.getName().endsWith(".txt") &&
+                        f.lastModified() + LOG_FILE_RETENTION < currentTime) {
+                    f.delete();
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Compresses the specified file into GZIP format with a timestamped filename.
+     */
+    private boolean compress(File file) {
+        try {
+            String baseName = file.getName().substring(0, file.getName().lastIndexOf('.'));
+            File compressed = new File(file.getParentFile(),
+                    baseName + "_" + LOG_FILE_TIME_FORMAT.format(new Date()) + ".gz");
+
+            try (FileInputStream input = new FileInputStream(file);
+                 FileOutputStream output = new FileOutputStream(compressed);
+                 GZIPOutputStream zipped = new GZIPOutputStream(output)) {
+
+                byte[] buffer = new byte[1024];
+                int length;
+                while ((length = input.read(buffer)) > 0) {
+                    zipped.write(buffer, 0, length);
+                }
+
+                zipped.finish();
+            }
+            return true;
+
+        } catch (IOException e) {
+            e.printStackTrace(); // Or log with Timber
+            return false;
+        }
+    }
+
+    /**
+     * Gets the file extension from a file name.
+     */
+    private String getFileExtension(String fileName) {
+        int lastDot = fileName.lastIndexOf('.');
+        return (lastDot >= 0) ? fileName.substring(lastDot + 1) : "";
+    }
+}

--- a/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
@@ -44,6 +44,8 @@ import java.util.ArrayList;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 
+import timber.log.Timber;
+
 public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener, MediaPlayer.OnCompletionListener {
     Intent intent;
     String query;
@@ -55,7 +57,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
     private BrailleDisplay brailleServiceObj = null;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Log.d("ACTIVITY", "FollowUpQuery Created");
+        Timber.d("ACTIVITY: "+ "FollowUpQuery Created");
         super.onCreate(savedInstanceState);
         brailleServiceObj = DataAndMethods.brailleServiceObj;
 
@@ -130,7 +132,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                 finish();
                 return true;
             default:
-                Log.d("KEY EVENT", event.toString());
+                Timber.d("KEY EVENT: "+ event.toString());
                 return false;
         }
     }
@@ -149,7 +151,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                         DataAndMethods.zoom(pins, "Exploration");
                     }
                     else {
-                        Log.d("TAGS", "ACCESS TTS");
+                        //Log.d("TAGS", "ACCESS TTS");
                         // Speak out label tags based on finger location and ping when detailed description is available
                         if ((tags.get(1)[pins[1]][pins[0]] != null) && (tags.get(1)[pins[1]][pins[0]].trim().length() > 0)) {
                             //Log.d("CHECKING!", tags.get(1)[pins[1]][pins[0]]);
@@ -161,7 +163,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                     }
                 }
                 catch(RuntimeException ex){
-                    Log.d("TTS ERROR", String.valueOf(ex));
+                    Timber.d(ex, "TTS ERROR");
                 } catch (XPathExpressionException e) {
                     throw new RuntimeException(e);
                 } catch (ParserConfigurationException e) {
@@ -183,7 +185,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
 
     @Override
     public boolean onDown(MotionEvent event) {
-        Log.d("GESTURE!","onDown: " + event.toString());
+        //Log.d("GESTURE!","onDown: " + event.toString());
 
         return true;
     }
@@ -191,7 +193,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
     @Override
     public boolean onFling(MotionEvent event1, MotionEvent event2,
                            float velocityX, float velocityY) {
-        Log.d("GESTURE!", "onFling: " + event1.toString() + event2.toString());
+        //Log.d("GESTURE!", "onFling: " + event1.toString() + event2.toString());
         return true;
     }
 
@@ -203,33 +205,33 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
             DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
         }
         catch(RuntimeException ex){
-            Log.d("TTS ERROR", String.valueOf(ex));
+            Timber.d(ex, "TTS ERROR");
         }
-        Log.d("GESTURE!", "onLongPress: " + event.toString());
+        // Log.d("GESTURE!", "onLongPress: " + event.toString());
 
     }
 
     @Override
     public boolean onScroll(MotionEvent event1, MotionEvent event2, float distanceX,
                             float distanceY) {
-        Log.d("GESTURE!", "onScroll: " + event1.toString() + event2.toString());
+        //Log.d("GESTURE!", "onScroll: " + event1.toString() + event2.toString());
         return true;
     }
 
     @Override
     public void onShowPress(MotionEvent event) {
-        Log.d("GESTURE!", "onShowPress: " + event.toString());
+        //Log.d("GESTURE!", "onShowPress: " + event.toString());
     }
 
     @Override
     public boolean onSingleTapUp(MotionEvent event) {
-        Log.d("GESTURE!", "onSingleTapUp: " + event.toString());
+        //Log.d("GESTURE!", "onSingleTapUp: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onDoubleTap(MotionEvent event) {
-        Log.d("GESTURE!", "onDoubleTap: " + event.toString());
+        Timber.d("GESTURE!: "+ "onDoubleTap: " + event.toString());
         Integer [] pins=DataAndMethods.pinCheck(event.getX(), event.getY());
         /*switch(state){
             case 0:
@@ -266,19 +268,19 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
 
     @Override
     public boolean onDoubleTapEvent(MotionEvent event) {
-        Log.d("GESTURE!", "onDoubleTapEvent: " + event.toString());
+        //Log.d("GESTURE!", "onDoubleTapEvent: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onSingleTapConfirmed(MotionEvent event) {
-        Log.d("GESTURE!", "onSingleTapConfirmed: " + event.toString());
+        //Log.d("GESTURE!", "onSingleTapConfirmed: " + event.toString());
         return true;
     }
 
     @Override
     protected void onResume() {
-        Log.d("ACTIVITY", "FollowUpQuery Resumed");
+        Timber.d("ACTIVITY: "+ "FollowUpQuery Resumed");
         intent = getIntent();
         query = intent.getStringExtra("query");
 
@@ -290,7 +292,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                     onTouchEvent(e);
                 }
                 catch(RuntimeException ex){
-                    Log.d("MOTION EVENT", String.valueOf(ex));
+                    Timber.e(ex, "EXCEPTION");
                 }
 
             return false;
@@ -303,7 +305,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
     }
     @Override
     protected void onPause() {
-        Log.d("ACTIVITY", "FollowUpQuery Paused");
+        Timber.d("ACTIVITY: "+ "FollowUpQuery Paused");
         DataAndMethods.presentLayer--;
         brailleServiceObj.unregisterMotionEventHandler(DataAndMethods.handler);
         super.onPause();

--- a/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/FollowUpQuery.java
@@ -72,6 +72,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                     brailleServiceObj.display(DataAndMethods.getBitmaps(DataAndMethods.getfreshDoc(), DataAndMethods.presentLayer, false));
                 } catch (IOException | XPathExpressionException | ParserConfigurationException |
                          SAXException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
                 DataAndMethods.speaker(getResources().getString(R.string.received_query_0)+query+" "+getResources().getString(R.string.received_query_1_temp), TextToSpeech.QUEUE_FLUSH);
@@ -100,6 +101,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                         try {
                             DataAndMethods.sendFollowUpQuery(query, region);
                         } catch (JSONException | IOException e) {
+                            Timber.e(e, "EXCEPTION");
                             throw new RuntimeException(e);
                         }
                         titleRead = false;
@@ -164,13 +166,8 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
                 }
                 catch(RuntimeException ex){
                     Timber.d(ex, "TTS ERROR");
-                } catch (XPathExpressionException e) {
-                    throw new RuntimeException(e);
-                } catch (ParserConfigurationException e) {
-                    throw new RuntimeException(e);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                } catch (SAXException e) {
+                } catch (XPathExpressionException | ParserConfigurationException | IOException | SAXException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
             }
@@ -205,7 +202,7 @@ public class FollowUpQuery extends BaseActivity implements GestureDetector.OnGes
             DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
         }
         catch(RuntimeException ex){
-            Timber.d(ex, "TTS ERROR");
+            Timber.e(ex, "TTS ERROR");
         }
         // Log.d("GESTURE!", "onLongPress: " + event.toString());
 

--- a/app/src/main/java/ca/mcgill/a11y/image/History.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/History.java
@@ -1,7 +1,5 @@
 package ca.mcgill.a11y.image;
 
-import android.util.Log;
-
 import com.google.gson.Gson;
 
 import org.json.JSONException;

--- a/app/src/main/java/ca/mcgill/a11y/image/ShowFollowUp.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/ShowFollowUp.java
@@ -101,13 +101,8 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
                 }
                 catch(RuntimeException ex){
                     Timber.e(ex, "TTS ERROR");
-                } catch (XPathExpressionException e) {
-                    throw new RuntimeException(e);
-                } catch (ParserConfigurationException e) {
-                    throw new RuntimeException(e);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                } catch (SAXException e) {
+                } catch (XPathExpressionException | ParserConfigurationException | IOException | SAXException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
             }
@@ -191,13 +186,8 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
         mainGraphic = intent.getStringExtra("image");
         try {
             brailleServiceObj.display(DataAndMethods.getBitmaps(DataAndMethods.getfreshDoc(), 0, true));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (XPathExpressionException e) {
-            throw new RuntimeException(e);
-        } catch (ParserConfigurationException e) {
-            throw new RuntimeException(e);
-        } catch (SAXException e) {
+        } catch (IOException | XPathExpressionException | ParserConfigurationException | SAXException e) {
+            Timber.e(e, "EXCEPTION");
             throw new RuntimeException(e);
         }
         mDetector = new GestureDetectorCompat(this,this);
@@ -223,13 +213,8 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
         resetGraphicParams();
         try {
             setImageDims();
-        } catch (ParserConfigurationException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (SAXException e) {
-            throw new RuntimeException(e);
-        } catch (XPathExpressionException e) {
+        } catch (ParserConfigurationException | IOException | SAXException | XPathExpressionException e) {
+            Timber.e(e, "EXCEPTION");
             throw new RuntimeException(e);
         }
         DataAndMethods.tempImage = "";

--- a/app/src/main/java/ca/mcgill/a11y/image/ShowFollowUp.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/ShowFollowUp.java
@@ -43,6 +43,8 @@ import java.util.ArrayList;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 
+import timber.log.Timber;
+
 public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener, MediaPlayer.OnCompletionListener {
     Intent intent;
     String mainGraphic;
@@ -50,7 +52,7 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
     private BrailleDisplay brailleServiceObj = null;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Log.d("ACTIVITY", "FollowUpQuery Created");
+        Timber.d("ACTIVITY: "+ "FollowUpQuery Created");
         super.onCreate(savedInstanceState);
         brailleServiceObj = DataAndMethods.brailleServiceObj;
 
@@ -67,7 +69,7 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
                 finish();
                 return true;
             default:
-                Log.d("KEY EVENT", event.toString());
+                Timber.d("KEY EVENT: "+ event.toString());
                 return false;
         }
     }
@@ -86,7 +88,7 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
                         DataAndMethods.zoom(pins, "Exploration");
                     }
                     else {
-                        Log.d("TAGS", "ACCESS TTS");
+                        //Log.d("TAGS", "ACCESS TTS");
                         // Speak out label tags based on finger location and ping when detailed description is available
                         if ((tags.get(1)[pins[1]][pins[0]] != null) && (tags.get(1)[pins[1]][pins[0]].trim().length() > 0)) {
                             //Log.d("CHECKING!", tags.get(1)[pins[1]][pins[0]]);
@@ -98,7 +100,7 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
                     }
                 }
                 catch(RuntimeException ex){
-                    Log.d("TTS ERROR", String.valueOf(ex));
+                    Timber.e(ex, "TTS ERROR");
                 } catch (XPathExpressionException e) {
                     throw new RuntimeException(e);
                 } catch (ParserConfigurationException e) {
@@ -120,7 +122,7 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
 
     @Override
     public boolean onDown(MotionEvent event) {
-        Log.d("GESTURE!","onDown: " + event.toString());
+        //Log.d("GESTURE!","onDown: " + event.toString());
 
         return true;
     }
@@ -128,7 +130,7 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
     @Override
     public boolean onFling(MotionEvent event1, MotionEvent event2,
                            float velocityX, float velocityY) {
-        Log.d("GESTURE!", "onFling: " + event1.toString() + event2.toString());
+        //Log.d("GESTURE!", "onFling: " + event1.toString() + event2.toString());
         return true;
     }
 
@@ -140,51 +142,51 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
             DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
         }
         catch(RuntimeException ex){
-            Log.d("TTS ERROR", String.valueOf(ex));
+            Timber.e(ex, "TTS ERROR");
         }
-        Log.d("GESTURE!", "onLongPress: " + event.toString());
+        // Log.d("GESTURE!", "onLongPress: " + event.toString());
 
     }
 
     @Override
     public boolean onScroll(MotionEvent event1, MotionEvent event2, float distanceX,
                             float distanceY) {
-        Log.d("GESTURE!", "onScroll: " + event1.toString() + event2.toString());
+        // Log.d("GESTURE!", "onScroll: " + event1.toString() + event2.toString());
         return true;
     }
 
     @Override
     public void onShowPress(MotionEvent event) {
-        Log.d("GESTURE!", "onShowPress: " + event.toString());
+        // Log.d("GESTURE!", "onShowPress: " + event.toString());
     }
 
     @Override
     public boolean onSingleTapUp(MotionEvent event) {
-        Log.d("GESTURE!", "onSingleTapUp: " + event.toString());
+        // Log.d("GESTURE!", "onSingleTapUp: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onDoubleTap(MotionEvent event) {
-        Log.d("GESTURE!", "onDoubleTap: " + event.toString());
+        // Log.d("GESTURE!", "onDoubleTap: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onDoubleTapEvent(MotionEvent event) {
-        Log.d("GESTURE!", "onDoubleTapEvent: " + event.toString());
+        // Log.d("GESTURE!", "onDoubleTapEvent: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onSingleTapConfirmed(MotionEvent event) {
-        Log.d("GESTURE!", "onSingleTapConfirmed: " + event.toString());
+        // Log.d("GESTURE!", "onSingleTapConfirmed: " + event.toString());
         return true;
     }
 
     @Override
     protected void onResume() {
-        Log.d("ACTIVITY", "FollowUpQuery Resumed");
+        Timber.d("ACTIVITY: "+ "FollowUpQuery Resumed");
         intent = getIntent();
         mainGraphic = intent.getStringExtra("image");
         try {
@@ -206,7 +208,7 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
                     onTouchEvent(e);
                 }
                 catch(RuntimeException ex){
-                    Log.d("MOTION EVENT", String.valueOf(ex));
+                    Timber.e(ex, "EXCEPTION" );
                 }
 
             return false;
@@ -216,7 +218,7 @@ public class ShowFollowUp extends BaseActivity implements GestureDetector.OnGest
     }
     @Override
     protected void onPause() {
-        Log.d("ACTIVITY", "FollowUpQuery Paused");
+        Timber.d("ACTIVITY: "+ "FollowUpQuery Paused");
         DataAndMethods.image = mainGraphic;
         resetGraphicParams();
         try {

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/BasicPhotoMapRenderer.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/BasicPhotoMapRenderer.java
@@ -44,6 +44,7 @@ import javax.xml.xpath.XPathExpressionException;
 import ca.mcgill.a11y.image.BaseActivity;
 import ca.mcgill.a11y.image.DataAndMethods;
 import ca.mcgill.a11y.image.R;
+import timber.log.Timber;
 
 // renders graphic currently stored in string 'image'
 public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener, MediaPlayer.OnCompletionListener  {
@@ -69,14 +70,10 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
                     try {
                         DataAndMethods.onShowFollowUp();
                     } catch (UnsupportedEncodingException e) {
+                        Timber.e(e, "EXCEPTION");
                         throw new RuntimeException(e);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    } catch (XPathExpressionException e) {
-                        throw new RuntimeException(e);
-                    } catch (ParserConfigurationException e) {
-                        throw new RuntimeException(e);
-                    } catch (SAXException e) {
+                    } catch (IOException | XPathExpressionException | ParserConfigurationException | SAXException e) {
+                        Timber.e(e, "EXCEPTION");
                         throw new RuntimeException(e);
                     }
                 }
@@ -97,7 +94,7 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
                 DataAndMethods.speechRecognizer.startListening(DataAndMethods.speechRecognizerIntent);
                 return true;
             default:
-                Log.d("KEY EVENT", event.toString());
+                Timber.d("KEY EVENT: "+ event.toString());
                 return true;
         }
     }
@@ -120,7 +117,7 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
                         DataAndMethods.zoom(pins, "Exploration");
                     }
                     else {
-                        Log.d("TAGS", "ACCESS TTS");
+                        //Log.d("TAGS", "ACCESS TTS");
                         // Speak out label tags based on finger location and ping when detailed description is available
                         if ((tags.get(1)[pins[1]][pins[0]] != null) && (tags.get(1)[pins[1]][pins[0]].trim().length() > 0)) {
                             //Log.d("CHECKING!", tags.get(1)[pins[1]][pins[0]]);
@@ -132,14 +129,9 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
                     }
                 }
                 catch(RuntimeException ex){
-                    Log.d("TTS ERROR", String.valueOf(ex));
-                } catch (XPathExpressionException e) {
-                    throw new RuntimeException(e);
-                } catch (ParserConfigurationException e) {
-                    throw new RuntimeException(e);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                } catch (SAXException e) {
+                    Timber.e(ex, "TTS ERROR");
+                } catch (XPathExpressionException | ParserConfigurationException | IOException | SAXException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
             }
@@ -149,7 +141,7 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
 
     @Override
     public boolean onDown(MotionEvent event) {
-        Log.d("GESTURE!","onDown: " + event.toString());
+        //Log.d("GESTURE!","onDown: " + event.toString());
 
         return true;
     }
@@ -157,7 +149,7 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
     @Override
     public boolean onFling(MotionEvent event1, MotionEvent event2,
                            float velocityX, float velocityY) {
-        Log.d("GESTURE!", "onFling: " + event1.toString() + event2.toString());
+        //Log.d("GESTURE!", "onFling: " + event1.toString() + event2.toString());
         return true;
     }
 
@@ -169,51 +161,51 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
             DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
         }
         catch(RuntimeException ex){
-            Log.d("TTS ERROR", String.valueOf(ex));
+            Timber.e(ex, "TTS ERROR");
         }
-        Log.d("GESTURE!", "onLongPress: " + event.toString());
+        //Log.d("GESTURE!", "onLongPress: " + event.toString());
 
     }
 
     @Override
     public boolean onScroll(MotionEvent event1, MotionEvent event2, float distanceX,
                             float distanceY) {
-        Log.d("GESTURE!", "onScroll: " + event1.toString() + event2.toString());
+        // Log.d("GESTURE!", "onScroll: " + event1.toString() + event2.toString());
         return true;
     }
 
     @Override
     public void onShowPress(MotionEvent event) {
-        Log.d("GESTURE!", "onShowPress: " + event.toString());
+        // Log.d("GESTURE!", "onShowPress: " + event.toString());
     }
 
     @Override
     public boolean onSingleTapUp(MotionEvent event) {
-        Log.d("GESTURE!", "onSingleTapUp: " + event.toString());
+        // Log.d("GESTURE!", "onSingleTapUp: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onDoubleTap(MotionEvent event) {
-        Log.d("GESTURE!", "onDoubleTap: " + event.toString());
+        // Log.d("GESTURE!", "onDoubleTap: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onDoubleTapEvent(MotionEvent event) {
-        Log.d("GESTURE!", "onDoubleTapEvent: " + event.toString());
+        // Log.d("GESTURE!", "onDoubleTapEvent: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onSingleTapConfirmed(MotionEvent event) {
-        Log.d("GESTURE!", "onSingleTapConfirmed: " + event.toString());
+        // Log.d("GESTURE!", "onSingleTapConfirmed: " + event.toString());
         return true;
     }
 
     @Override
     protected void onResume() {
-        Log.d("ACTIVITY", "Exploration Resumed");
+        Timber.d("ACTIVITY: "+ "Exploration Resumed");
 
         DataAndMethods.displayGraphic(DataAndMethods.confirmButton, "Exploration", silentStart);
         silentStart = false;
@@ -227,7 +219,7 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
                     onTouchEvent(e);
                 }
                 catch(RuntimeException ex){
-                    Log.d("MOTION EVENT", String.valueOf(ex));
+                    Timber.e(ex, "EXCEPTION");
                 }}
 
             return false;
@@ -237,7 +229,7 @@ public class BasicPhotoMapRenderer extends BaseActivity implements GestureDetect
     }
     @Override
     protected void onPause() {
-        Log.d("ACTIVITY", "BasicPhotoMapRenderer Paused");
+        Timber.d("ACTIVITY: "+ "BasicPhotoMapRenderer Paused");
         brailleServiceObj.unregisterMotionEventHandler(DataAndMethods.handler);
         super.onPause();
     }

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/Exploration.java
@@ -56,6 +56,7 @@ import ca.mcgill.a11y.image.BaseActivity;
 import ca.mcgill.a11y.image.DataAndMethods;
 import ca.mcgill.a11y.image.PollingService;
 import ca.mcgill.a11y.image.R;
+import timber.log.Timber;
 
 public class Exploration extends BaseActivity implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener, MediaPlayer.OnCompletionListener {
     private BrailleDisplay brailleServiceObj = null;
@@ -106,12 +107,11 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
                 case "UP":
                 case "DOWN":
                     // make force refresh
-                    Log.d("KEY EVENT", event.toString());
+                    // Log.d("KEY EVENT", event.toString());
                     try {
                         DataAndMethods.checkForUpdate();
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    } catch (JSONException e) {
+                    } catch (IOException | JSONException e) {
+                        Timber.e(e, "EXCEPTION");
                         throw new RuntimeException(e);
                     }
                     //DataAndMethods.checkForUpdate();
@@ -131,7 +131,7 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
                     DataAndMethods.speechRecognizer.startListening(DataAndMethods.speechRecognizerIntent);
                     return true;
                 default:
-                    Log.d("KEY EVENT", event.toString());
+                    Timber.d("KEY EVENT: "+ event.toString());
                     return false;
             }
     }
@@ -149,7 +149,7 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
                         DataAndMethods.zoom(pins, "Exploration");
                     }
                     else {
-                        Log.d("TAGS", "ACCESS TTS");
+                        // Log.d("TAGS", "ACCESS TTS");
                         // Speak out label tags based on finger location and ping when detailed description is available
                         if ((tags.get(1)[pins[1]][pins[0]] != null) && (tags.get(1)[pins[1]][pins[0]].trim().length() > 0)) {
                             //Log.d("CHECKING!", tags.get(1)[pins[1]][pins[0]]);
@@ -161,14 +161,9 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
                     }
                 }
                 catch(RuntimeException ex){
-                    Log.d("TTS ERROR", String.valueOf(ex));
-                } catch (XPathExpressionException e) {
-                    throw new RuntimeException(e);
-                } catch (ParserConfigurationException e) {
-                    throw new RuntimeException(e);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                } catch (SAXException e) {
+                    Timber.e(ex, "TTS ERROR");
+                } catch (XPathExpressionException | ParserConfigurationException | IOException | SAXException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
             }
@@ -178,7 +173,7 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
 
     @Override
     public boolean onDown(MotionEvent event) {
-        Log.d("GESTURE!","onDown: " + event.toString());
+        // Log.d("GESTURE!","onDown: " + event.toString());
 
         return true;
     }
@@ -186,7 +181,7 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
     @Override
     public boolean onFling(MotionEvent event1, MotionEvent event2,
                            float velocityX, float velocityY) {
-        Log.d("GESTURE!", "onFling: " + event1.toString() + event2.toString());
+        // Log.d("GESTURE!", "onFling: " + event1.toString() + event2.toString());
         return true;
     }
 
@@ -198,45 +193,45 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
             DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
         }
         catch(RuntimeException ex){
-            Log.d("TTS ERROR", String.valueOf(ex));
+            Timber.e(ex, "TTS ERROR");
         }
-        Log.d("GESTURE!", "onLongPress: " + event.toString());
+        //Log.d("GESTURE!", "onLongPress: " + event.toString());
 
     }
 
     @Override
     public boolean onScroll(MotionEvent event1, MotionEvent event2, float distanceX,
                             float distanceY) {
-        Log.d("GESTURE!", "onScroll: " + event1.toString() + event2.toString());
+        // Log.d("GESTURE!", "onScroll: " + event1.toString() + event2.toString());
         return true;
     }
 
     @Override
     public void onShowPress(MotionEvent event) {
-        Log.d("GESTURE!", "onShowPress: " + event.toString());
+        // Log.d("GESTURE!", "onShowPress: " + event.toString());
     }
 
     @Override
     public boolean onSingleTapUp(MotionEvent event) {
-        Log.d("GESTURE!", "onSingleTapUp: " + event.toString());
+        // Log.d("GESTURE!", "onSingleTapUp: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onDoubleTap(MotionEvent event) {
-        Log.d("GESTURE!", "onDoubleTap: " + event.toString());
+        // Log.d("GESTURE!", "onDoubleTap: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onDoubleTapEvent(MotionEvent event) {
-        Log.d("GESTURE!", "onDoubleTapEvent: " + event.toString());
+        // Log.d("GESTURE!", "onDoubleTapEvent: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onSingleTapConfirmed(MotionEvent event) {
-        Log.d("GESTURE!", "onSingleTapConfirmed: " + event.toString());
+        // Log.d("GESTURE!", "onSingleTapConfirmed: " + event.toString());
         return true;
     }
 
@@ -247,7 +242,7 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
 
     @Override
     protected void onResume() {
-        Log.d("ACTIVITY", "Exploration Resumed");
+        Timber.d("ACTIVITY: "+ "Exploration Resumed");
         if (!silentStart)
             DataAndMethods.speaker(getString(R.string.exploration_mode), TextToSpeech.QUEUE_FLUSH);
 
@@ -263,7 +258,7 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
                     onTouchEvent(e);
                 }
                 catch(RuntimeException ex){
-                    Log.d("MOTION EVENT", String.valueOf(ex));
+                    Timber.e(ex, "EXCEPTION");
                 }}
 
             return false;
@@ -273,7 +268,7 @@ public class Exploration extends BaseActivity implements GestureDetector.OnGestu
     }
     @Override
     protected void onPause() {
-        Log.d("ACTIVITY", "Exploration Paused");
+        Timber.d("ACTIVITY: "+ "Exploration Paused");
         stopService(new Intent(getApplicationContext(), PollingService.class));
         brailleServiceObj.unregisterMotionEventHandler(DataAndMethods.handler);
         super.onPause();

--- a/app/src/main/java/ca/mcgill/a11y/image/renderers/Guidance.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/renderers/Guidance.java
@@ -50,6 +50,7 @@ import ca.mcgill.a11y.image.DataAndMethods;
 import ca.mcgill.a11y.image.PollingService;
 
 import ca.mcgill.a11y.image.R;
+import timber.log.Timber;
 
 public class Guidance extends BaseActivity implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener, MediaPlayer.OnCompletionListener {
     private BrailleDisplay brailleServiceObj = null;
@@ -89,12 +90,11 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
                 case "UP":
                 case "DOWN":
                     // make force refresh
-                    Log.d("KEY EVENT", event.toString());
+                    // Log.d("KEY EVENT", event.toString());
                     try {
                         DataAndMethods.checkForUpdate();
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    } catch (JSONException e) {
+                    } catch (IOException | JSONException e) {
+                        Timber.e(e, "EXCEPTION");
                         throw new RuntimeException(e);
                     }
                     //DataAndMethods.checkForUpdate();
@@ -110,7 +110,7 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
                         DataAndMethods.displayGraphic(backButton, "Guidance", false);
                     return false;
                 default:
-                    Log.d("KEY EVENT", event.toString());
+                    Timber.d("KEY EVENT: "+ event.toString());
                     return false;
             }
     }
@@ -128,7 +128,7 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
                         DataAndMethods.zoom(pins, "Guidance");
                     }
                     else {
-                        Log.d("TAGS", "ACCESS TTS");
+                        // Log.d("TAGS", "ACCESS TTS");
                         // Speak out label tags based on finger location and ping when detailed description is available
                         if ((tags.get(1)[pins[1]][pins[0]] != null) && (tags.get(1)[pins[1]][pins[0]].trim().length() > 0)) {
                             //Log.d("CHECKING!", tags.get(1)[pins[1]][pins[0]]);
@@ -140,14 +140,9 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
                     }
                 }
                 catch(RuntimeException ex){
-                    Log.d("TTS ERROR", String.valueOf(ex));
-                } catch (XPathExpressionException e) {
-                    throw new RuntimeException(e);
-                } catch (ParserConfigurationException e) {
-                    throw new RuntimeException(e);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                } catch (SAXException e) {
+                    Timber.e(ex, "TTS ERROR");
+                } catch (XPathExpressionException | ParserConfigurationException | IOException | SAXException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
             }
@@ -157,7 +152,7 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
 
     @Override
     public boolean onDown(MotionEvent event) {
-        Log.d("GESTURE!","onDown: " + event.toString());
+        // Log.d("GESTURE!","onDown: " + event.toString());
 
         return true;
     }
@@ -165,7 +160,7 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
     @Override
     public boolean onFling(MotionEvent event1, MotionEvent event2,
                            float velocityX, float velocityY) {
-        Log.d("GESTURE!", "onFling: " + event1.toString() + event2.toString());
+        // Log.d("GESTURE!", "onFling: " + event1.toString() + event2.toString());
         return true;
     }
 
@@ -177,33 +172,33 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
             DataAndMethods.speaker(DataAndMethods.tags.get(1)[pins[1]][pins[0]], TextToSpeech.QUEUE_FLUSH);
         }
         catch(RuntimeException ex){
-            Log.d("TTS ERROR", String.valueOf(ex));
+            Timber.e(ex, "TTS ERROR");
         }
-        Log.d("GESTURE!", "onLongPress: " + event.toString());
+        // Log.d("GESTURE!", "onLongPress: " + event.toString());
 
     }
 
     @Override
     public boolean onScroll(MotionEvent event1, MotionEvent event2, float distanceX,
                             float distanceY) {
-        Log.d("GESTURE!", "onScroll: " + event1.toString() + event2.toString());
+        // Log.d("GESTURE!", "onScroll: " + event1.toString() + event2.toString());
         return true;
     }
 
     @Override
     public void onShowPress(MotionEvent event) {
-        Log.d("GESTURE!", "onShowPress: " + event.toString());
+        // Log.d("GESTURE!", "onShowPress: " + event.toString());
     }
 
     @Override
     public boolean onSingleTapUp(MotionEvent event) {
-        Log.d("GESTURE!", "onSingleTapUp: " + event.toString());
+        // Log.d("GESTURE!", "onSingleTapUp: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onDoubleTap(MotionEvent event) {
-        Log.d("GESTURE!", "onDoubleTap: " + event.toString());
+        // Log.d("GESTURE!", "onDoubleTap: " + event.toString());
         try {
             if (!DataAndMethods.showAll)
                 brailleServiceObj.display(DataAndMethods.displayTargetLayer(DataAndMethods.getfreshDoc()));
@@ -212,13 +207,8 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
                 DataAndMethods.showAll = !DataAndMethods.showAll;
             }
             //DataAndMethods.showAll = !DataAndMethods.showAll;
-        } catch (XPathExpressionException e) {
-            throw new RuntimeException(e);
-        } catch (ParserConfigurationException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (SAXException e) {
+        } catch (XPathExpressionException | ParserConfigurationException | IOException | SAXException e) {
+            Timber.e(e, "EXCEPTION");
             throw new RuntimeException(e);
         }
         return true;
@@ -226,13 +216,13 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
 
     @Override
     public boolean onDoubleTapEvent(MotionEvent event) {
-        Log.d("GESTURE!", "onDoubleTapEvent: " + event.toString());
+        // Log.d("GESTURE!", "onDoubleTapEvent: " + event.toString());
         return true;
     }
 
     @Override
     public boolean onSingleTapConfirmed(MotionEvent event) {
-        Log.d("GESTURE!", "onSingleTapConfirmed: " + event.toString());
+        // Log.d("GESTURE!", "onSingleTapConfirmed: " + event.toString());
         return true;
     }
 
@@ -244,7 +234,7 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
 
     @Override
     protected void onResume() {
-        Log.d("ACTIVITY", "Guidance Resumed");
+        Timber.d("ACTIVITY: "+ "Guidance Resumed");
         DataAndMethods.speaker(getString(R.string.guidance_mode), TextToSpeech.QUEUE_FLUSH);
         startService(new Intent(getApplicationContext(), PollingService.class));
         mDetector = new GestureDetectorCompat(this,this);
@@ -256,7 +246,7 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
                     onTouchEvent(e);
                 }
                 catch(RuntimeException ex){
-                    Log.d("MOTION EVENT", String.valueOf(ex));
+                    Timber.e(ex, "TTS ERROR");
                 }}
 
             return false;
@@ -266,7 +256,7 @@ public class Guidance extends BaseActivity implements GestureDetector.OnGestureL
     }
     @Override
     protected void onPause() {
-        Log.d("ACTIVITY", "Guidance Paused");
+        Timber.d("ACTIVITY: "+ "Guidance Paused");
         stopService(new Intent(getApplicationContext(), PollingService.class));
         brailleServiceObj.unregisterMotionEventHandler(DataAndMethods.handler);
         super.onPause();

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/ClassroomSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/ClassroomSelector.java
@@ -124,9 +124,8 @@ public class ClassroomSelector extends BaseActivity implements MediaPlayer.OnCom
                 //Log.d("KEY EVENT", event.toString());
                 try {
                     DataAndMethods.checkForUpdate();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                } catch (JSONException e) {
+                } catch (IOException | JSONException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
                 return true;

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/ClassroomSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/ClassroomSelector.java
@@ -57,6 +57,7 @@ import ca.mcgill.a11y.image.PollingService;
 import ca.mcgill.a11y.image.R;
 import ca.mcgill.a11y.image.renderers.Exploration;
 import ca.mcgill.a11y.image.renderers.Guidance;
+import timber.log.Timber;
 
 public class ClassroomSelector extends BaseActivity implements MediaPlayer.OnCompletionListener {
     public static String channelSubscribed; // make this the place the request takes it from
@@ -120,7 +121,7 @@ public class ClassroomSelector extends BaseActivity implements MediaPlayer.OnCom
             case "UP":
             case "DOWN":
                 // make force refresh
-                Log.d("KEY EVENT", event.toString());
+                //Log.d("KEY EVENT", event.toString());
                 try {
                     DataAndMethods.checkForUpdate();
                 } catch (IOException e) {
@@ -133,7 +134,7 @@ public class ClassroomSelector extends BaseActivity implements MediaPlayer.OnCom
                 finish();
                 return false;
             default:
-                Log.d("KEY EVENT", event.toString());
+                Timber.d("KEY EVENT: "+ event.toString());
                 return false;
         }
     }
@@ -150,14 +151,14 @@ public class ClassroomSelector extends BaseActivity implements MediaPlayer.OnCom
 
     @Override
     protected void onResume() {
-        Log.d("ACTIVITY", "Classroom Selector Resumed");
+        Timber.d("ACTIVITY: "+ "Classroom Selector Resumed");
         DataAndMethods.speaker(getResources().getString(R.string.res_classroom_selector), TextToSpeech.QUEUE_FLUSH);
         //startService(new Intent(getApplicationContext(), PollingService.class));
         super.onResume();
     }
     @Override
     protected void onPause() {
-        Log.d("ACTIVITY", "Exploration Paused");
+        Timber.d("ACTIVITY: "+ "Exploration Paused");
         //stopService(new Intent(getApplicationContext(), PollingService.class));
         super.onPause();
     }

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/MapSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/MapSelector.java
@@ -79,6 +79,7 @@ public class MapSelector extends AppCompatActivity implements MediaPlayer.OnComp
                 } catch (NumberFormatException e){
                     speaker(getResources().getString(R.string.invalid_coord), TextToSpeech.QUEUE_FLUSH);
                 } catch (JSONException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
                 //startActivity(new Intent(getApplicationContext(), BasicPhotoMapRenderer.class));

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/MapSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/MapSelector.java
@@ -36,6 +36,7 @@ import org.json.JSONException;
 import ca.mcgill.a11y.image.renderers.BasicPhotoMapRenderer;
 import ca.mcgill.a11y.image.DataAndMethods;
 import ca.mcgill.a11y.image.R;
+import timber.log.Timber;
 
 // generates map request using latitude and longitude coordinates and allows for selecting among map renderer(s) 
 public class MapSelector extends AppCompatActivity implements MediaPlayer.OnCompletionListener{
@@ -86,7 +87,7 @@ public class MapSelector extends AppCompatActivity implements MediaPlayer.OnComp
                 finish();
                 return false;
             default:
-                Log.d("KEY EVENT", event.toString());
+                Timber.d("KEY EVENT: "+ event.toString());
                 return false;
         }
     }
@@ -105,14 +106,14 @@ public class MapSelector extends AppCompatActivity implements MediaPlayer.OnComp
 
     @Override
     protected void onResume() {
-        Log.d("ACTIVITY", "MapSelector Resumed");
+        Timber.d("ACTIVITY: "+"MapSelector Resumed");
         DataAndMethods.speaker(getResources().getString(R.string.res_map_selector), TextToSpeech.QUEUE_FLUSH);
         DataAndMethods.image= null;
         super.onResume();
     }
     @Override
     protected void onPause() {
-        Log.d("ACTIVITY", "MapSelector Paused");
+        Timber.d("ACTIVITY: "+ "MapSelector Paused");
         super.onPause();
     }
 }

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/ModeSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/ModeSelector.java
@@ -42,6 +42,7 @@ import ca.mcgill.a11y.image.BaseActivity;
 import ca.mcgill.a11y.image.DataAndMethods;
 import ca.mcgill.a11y.image.renderers.Exploration;
 import ca.mcgill.a11y.image.R;
+import timber.log.Timber;
 
 // Launcher activity; switches mode of application
 public class ModeSelector extends BaseActivity implements MediaPlayer.OnCompletionListener {
@@ -127,7 +128,7 @@ public class ModeSelector extends BaseActivity implements MediaPlayer.OnCompleti
 
     @Override
     protected void onResume() {
-        Log.d("ACTIVITY", "ModeSelector Resumed");
+        Timber.d("ACTIVITY: "+ "ModeSelector Resumed");
         DataAndMethods.speaker(getResources().getString(R.string.res_mode_selector), TextToSpeech.QUEUE_FLUSH);
         DataAndMethods.image = null;
         update.setValue(false);
@@ -135,7 +136,7 @@ public class ModeSelector extends BaseActivity implements MediaPlayer.OnCompleti
     }
     @Override
     protected void onPause() {
-        Log.d("ACTIVITY", "ModeSelector Paused");
+        Timber.d("ACTIVITY: "+ "ModeSelector Paused");
         super.onPause();
     }
 

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/PhotoSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/PhotoSelector.java
@@ -66,8 +66,10 @@ public class PhotoSelector extends BaseActivity implements MediaPlayer.OnComplet
                 try {
                     DataAndMethods.speaker(DataAndMethods.getFile(++fileSelected), TextToSpeech.QUEUE_FLUSH);
                 } catch (IOException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 } catch (JSONException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
                 return true;
@@ -76,8 +78,10 @@ public class PhotoSelector extends BaseActivity implements MediaPlayer.OnComplet
                 try {
                     DataAndMethods.speaker(DataAndMethods.getFile(--fileSelected), TextToSpeech.QUEUE_FLUSH);
                 } catch (IOException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 } catch (JSONException e) {
+                    Timber.e(e, "EXCEPTION");
                     throw new RuntimeException(e);
                 }
                 return true;
@@ -115,8 +119,10 @@ public class PhotoSelector extends BaseActivity implements MediaPlayer.OnComplet
             // might want to read file name here
             DataAndMethods.getFile(++DataAndMethods.fileSelected);
         } catch (IOException e) {
+            Timber.e(e, "EXCEPTION");
             throw new RuntimeException(e);
         } catch (JSONException e) {
+            Timber.e(e, "EXCEPTION");
             throw new RuntimeException(e);
         }
         super.onResume();

--- a/app/src/main/java/ca/mcgill/a11y/image/selectors/PhotoSelector.java
+++ b/app/src/main/java/ca/mcgill/a11y/image/selectors/PhotoSelector.java
@@ -35,6 +35,7 @@ import ca.mcgill.a11y.image.BaseActivity;
 import ca.mcgill.a11y.image.renderers.BasicPhotoMapRenderer;
 import ca.mcgill.a11y.image.DataAndMethods;
 import ca.mcgill.a11y.image.R;
+import timber.log.Timber;
 
 // generates photo request by navigating files in specified directory and allows for selecting among photo renderer(s)
 public class PhotoSelector extends BaseActivity implements MediaPlayer.OnCompletionListener{
@@ -61,7 +62,7 @@ public class PhotoSelector extends BaseActivity implements MediaPlayer.OnComplet
         switch (keyMapping.getOrDefault(keyCode, "default")) {
             // Navigating between files
             case "UP":
-                Log.d("KEY EVENT", event.toString());
+                //Log.d("KEY EVENT", event.toString());
                 try {
                     DataAndMethods.speaker(DataAndMethods.getFile(++fileSelected), TextToSpeech.QUEUE_FLUSH);
                 } catch (IOException e) {
@@ -71,7 +72,7 @@ public class PhotoSelector extends BaseActivity implements MediaPlayer.OnComplet
                 }
                 return true;
             case "DOWN":
-                Log.d("KEY EVENT", event.toString());
+                //Log.d("KEY EVENT", event.toString());
                 try {
                     DataAndMethods.speaker(DataAndMethods.getFile(--fileSelected), TextToSpeech.QUEUE_FLUSH);
                 } catch (IOException e) {
@@ -90,7 +91,7 @@ public class PhotoSelector extends BaseActivity implements MediaPlayer.OnComplet
                 finish();
                 return false;
             default:
-                Log.d("KEY EVENT", event.toString());
+                Timber.d("KEY EVENT: "+event.toString());
                 return false;
         }
     }
@@ -109,7 +110,6 @@ public class PhotoSelector extends BaseActivity implements MediaPlayer.OnComplet
 
     @Override
     protected void onResume() {
-        Log.d("ACTIVITY", "PhotoSelector Resumed");
         DataAndMethods.speaker(getResources().getString(R.string.res_photo_selector), TextToSpeech.QUEUE_FLUSH);
         try {
             // might want to read file name here
@@ -123,7 +123,7 @@ public class PhotoSelector extends BaseActivity implements MediaPlayer.OnComplet
     }
     @Override
     protected void onPause() {
-        Log.d("ACTIVITY", "PhotoSelector Paused");
+        Timber.d("ACTIVITY: "+ "PhotoSelector Paused");
         super.onPause();
     }
 


### PR DESCRIPTION
This PR modifies the Monarch application to enable logging to file using Timber.

The logging logic (FileTree.java) works as follows:
1. Each time there is a new log, it is added to a buffer.
2. When either 20 logs have accumulated, the log level is ERROR or greater or 5 minutes have passed since the last flush (whichever occurs first) the current log file is checked. If its size exceeds 1 MB, the existing file is rotated (renamed with a timestamp to mark the latest possible log time). The buffered logs are then written into the current log file.
3. As part of log rotation, any rotated log files older than 7 days are deleted.

Multiple changes have been made across the application to redirect the logs to Timber.

TESTING:
1. Tested that new files with timestamps are generated after the 1MB limit by creating logs using a for loop after logging initialization.
2. Tested log retention by reducing it to 5 mins. 
3. Tested that flush occurs when the log level is ERROR

Closes #72 